### PR TITLE
Add support for adding attachments directly from an InputStream.

### DIFF
--- a/src/main/java/com/github/sendgrid/SendGrid.java
+++ b/src/main/java/com/github/sendgrid/SendGrid.java
@@ -2,8 +2,11 @@ package com.github.sendgrid;
 
 import com.github.kevinsawicki.http.HttpRequest;
 import org.json.JSONObject;
-import org.json.JSONException;
+
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.util.ArrayList;
 
 public class SendGrid {
@@ -32,7 +35,7 @@ public class SendGrid {
   private String subject;
   private String text;
   private String html;
-  private ArrayList<File> files = new ArrayList<File>();
+  private ArrayList<Attachment> attachments = new ArrayList<Attachment>();
   private JSONObject headers = new JSONObject();
   
   public SendGrid(String username, String password) {
@@ -80,8 +83,8 @@ public class SendGrid {
     if (this.getBcc() != null) {
       request.part(PARAM_BCC, this.getBcc());
     }
-    for (File file:this.getFiles()) {
-      request.part(String.format(PARAM_FILES, file.getName()), file);
+    for (Attachment attachment:this.getAttachments()) {
+      request.part(String.format(PARAM_FILES, attachment.name), attachment.contents);
     }
     request.part(PARAM_HEADERS,   this.getHeaders().toString());
 
@@ -124,8 +127,8 @@ public class SendGrid {
     return this.html;
   }
 
-  public ArrayList<File> getFiles() {
-    return this.files;
+  public ArrayList<Attachment> getAttachments() {
+    return this.attachments;
   }
 
   public JSONObject getHeaders() {
@@ -177,8 +180,8 @@ public class SendGrid {
     return this;
   }
 
-  public SendGrid addFile(File file) {
-    this.files.add(file);
+  public SendGrid addAttachment(Attachment attachment) {
+    this.attachments.add(attachment);
     return this;
   }
 
@@ -190,5 +193,23 @@ public class SendGrid {
     }
 
     return this;
+  }
+
+  public static class Attachment
+  {
+    public final String name;
+    public final InputStream contents;
+
+    public Attachment(File file) throws FileNotFoundException
+    {
+      this.name = file.getName();
+      this.contents = new FileInputStream(file);
+    }
+
+    public Attachment(String name, InputStream contents)
+    {
+      this.name = name;
+      this.contents = contents;
+    }
   }
 }

--- a/src/test/java/com/github/sendgrid/SendGridTest.java
+++ b/src/test/java/com/github/sendgrid/SendGridTest.java
@@ -1,12 +1,14 @@
 package com.github.sendgrid;
 
+import org.json.JSONException;
 import org.junit.Test;
+
 import java.io.File;
+import java.io.FileNotFoundException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.matchers.JUnitMatchers.hasItems;
-import org.json.JSONObject;
-import org.json.JSONException;
 
 public class SendGridTest {
   private static final String USERNAME = "username";
@@ -121,26 +123,27 @@ public class SendGridTest {
   }
 
   @Test
-  public void testAddFile() {
+  public void testAddFile() throws FileNotFoundException {
     SendGrid sendgrid = new SendGrid(USERNAME, PASSWORD);
 
     File file = new File(getClass().getResource("/test.txt").getFile());
-    sendgrid.addFile(file);
+    SendGrid.Attachment attachment = new SendGrid.Attachment(file);
+    sendgrid.addAttachment(attachment);
 
-    assertThat(sendgrid.getFiles(), hasItems(file)); 
+    assertThat(sendgrid.getAttachments(), hasItems(attachment));
   }
 
   @Test
-  public void testAddMultipleFiles() {
+  public void testAddMultipleFiles() throws FileNotFoundException {
     SendGrid sendgrid = new SendGrid(USERNAME, PASSWORD);
 
-    File file = new File(getClass().getResource("/test.txt").getFile());
-    File file2 = new File(getClass().getResource("/image.png").getFile());
+    SendGrid.Attachment attachment1 = new SendGrid.Attachment(new File(getClass().getResource("/test.txt").getFile()));
+    SendGrid.Attachment attachment2 = new SendGrid.Attachment(new File(getClass().getResource("/image.png").getFile()));
 
-    sendgrid.addFile(file);
-    sendgrid.addFile(file2);
+    sendgrid.addAttachment(attachment1);
+    sendgrid.addAttachment(attachment2);
 
-    assertThat(sendgrid.getFiles(), hasItems(file, file2)); 
+    assertThat(sendgrid.getAttachments(), hasItems(attachment1, attachment2));
   }
 
   @Test


### PR DESCRIPTION
Before only File where supported, however, Google App Engine does not
allow applications access to the filesystem, thus where unable to attach
any attachments.
This pull request fixes #8
