### PR TITLE
This fixes #6: adds ability to publish library to Maven Central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,12 @@
-apply plugin: 'fatjar'
+import org.gradle.api.artifacts.maven.MavenDeployment
 
+apply plugin: 'fatjar'
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+group = 'com.sendgrid'
 version       = "0.1.2"
+ext.packaging = 'jar'
 
 buildscript {
   dependencies {
@@ -39,6 +45,64 @@ build << {
   }
 }
 
+task javadocJar(type: Jar, dependsOn: javadoc) {
+  classifier = 'javadoc'
+  from 'build/docs/javadoc'
+}
+
+task sourcesJar(type: Jar) {
+  from sourceSets.main.allSource
+  classifier = 'sources'
+}
+
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(userName: sonatypeUsername, password: sonatypePassword)
+            }
+
+            pom.project {
+                name 'sendgrid-java'
+                packaging 'jar'
+                description 'SendGrid Java helper library'
+                url 'https://github.com/sendgrid/sendgrid-java'
+
+                scm {
+                    url 'scm:git@github.com:sendgrid/sendgrid-java.git'
+                    connection 'scm:git@github.com:sendgrid/sendgrid-java.git'
+                    developerConnection 'scm:git@github.com:sendgrid/sendgrid-java.git'
+                }
+
+                licenses {
+                    license {
+                        name 'MIT License'
+                        url 'http://opensource.org/licenses/MIT'
+                        distribution 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'scottmotte'
+                        name 'Scott Motte'
+                    }
+                }
+            }
+        }
+    }
+}
+
 artifacts {
   archives fatJar
+
+  archives jar
+  archives javadocJar
+  archives sourcesJar
 }


### PR DESCRIPTION
This prepares the build.gradle file for publishing the library to Maven Central.
It's in the lines of this article here:  http://yennicktrevels.com/blog/2013/10/11/automated-gradle-project-deployment-to-sonatype-oss-repository/

Next steps:
- create an account with OSS Sonatype for the "com.sendgrid" group
  (see https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide)
- create a public key and configure your ~/.gradle/gradle.properties
  (see https://docs.sonatype.org/display/Repository/How+To+Generate+PGP+Signatures+With+Maven and  http://yennicktrevels.com/blog/2013/10/11/automated-gradle-project-deployment-to-sonatype-oss-repository/ )
- do your first publish to Maven Central

```
$ gradle uploadArchives
```

and release the artifacts: https://oss.sonatype.org/index.html#stagingRepositories
