### PR TITLE
Change addTo() to generate the 'to' parameter instead of 'to' property on x-smtpapi parameter

### DIFF
--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Scanner;
+import java.util.List;
 import java.util.Map;
 
 import java.io.File;
@@ -52,7 +53,7 @@ public class SendGrid {
   }
 
   public static class Email {
-    private static final String PARAM_TO          = "to";
+    private static final String PARAM_TO          = "to[%d]";
     private static final String PARAM_FROM        = "from";
     private static final String PARAM_FROMNAME    = "fromname";
     private static final String PARAM_REPLYTO     = "replyto";
@@ -67,24 +68,29 @@ public class SendGrid {
     public SMTPAPI smtpapi;
     SMTPAPI header = new SMTPAPI();
 
-    public String to;
+    public List<String> to = new ArrayList<String>();
     public String from;
     public String fromname;
     public String replyto;
     public String subject;
     public String text;
     public String html;
-    public ArrayList<String> bcc = new ArrayList<String>();
+    public List<String> bcc = new ArrayList<String>();
     public Map attachments = new HashMap();
     public Map headers = new HashMap();
 
     public Email () {
-      this.smtpapi = new SMTPAPI(); 
+      this.smtpapi = new SMTPAPI();
     }
 
     public Email addTo(String to) {
-      this.smtpapi.addTo(to);
-      return this;
+        this.to.add(to);
+        return this;
+    }
+
+    public Email addSmtpApiTo(String to) {
+        this.smtpapi.addTo(to);
+        return this;
     }
 
     public Email setFrom(String from) {
@@ -123,22 +129,22 @@ public class SendGrid {
     }
 
     public Email addSubstitution(String key, String[] val) {       
-      this.smtpapi.addSubstitutions(key, val);               
-      return this;                                                     
+      this.smtpapi.addSubstitutions(key, val);
+      return this;
     }
-    
+
     public Email addUniqueArg(String key, String val) {                
       this.smtpapi.addUniqueArg(key, val);
       return this;
     }
-    
+
     public Email addCategory(String category) {                        
       this.smtpapi.addCategory(category);
       return this;
     }
- 
+
     public Email addSection(String key, String val) {                  
-      this.smtpapi.addSection(key, val);                               
+      this.smtpapi.addSection(key, val);
       return this;
     }
                                                                        
@@ -174,11 +180,10 @@ public class SendGrid {
     public Map toWebFormat() {
       Map body = new HashMap();
 
-      // updateMissingTo - There needs to be at least 1 to address,
-      // or else the mail won't send.
-      if ((this.to == null || this.to.isEmpty()) && this.from != null && !this.from.isEmpty()) {
-        String value = this.from; 
-        body.put(PARAM_TO, value);
+      for (int i = 0; i < this.to.size(); i++) {
+        String key = String.format(PARAM_TO, i);
+        String value = this.to.get(i);
+        body.put(key, value);
       }
 
       if (this.from != null && !this.from.isEmpty()) {

--- a/src/test/java/com/sendgrid/SendGridTest.java
+++ b/src/test/java/com/sendgrid/SendGridTest.java
@@ -1,23 +1,13 @@
 package com.sendgrid;
 
-import org.json.JSONException;
+import org.junit.Test;
 
-import java.util.Arrays;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.HashMap;
 import java.util.Map;
 
-import java.io.File;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-
-import com.mashape.unirest.http.exceptions.*;
-
-import org.junit.Test;
-import org.junit.Before;
-import static org.junit.Assert.*;
-import static org.junit.matchers.JUnitMatchers.hasItems;
+import static org.junit.Assert.assertEquals;
 
 public class SendGridTest {
   SendGrid.Email email;
@@ -34,7 +24,8 @@ public class SendGridTest {
     email.addTo(address2);
 
     Map correct = new HashMap();
-    correct.put("x-smtpapi", "{\"to\":[\"email@example.com\",\"email2@example.com\"]}");
+      correct.put("to[0]", address);
+      correct.put("to[1]", address2);
 
     assertEquals(correct, email.toWebFormat());
   }
@@ -48,9 +39,8 @@ public class SendGridTest {
     email.setFrom(fromaddress);
 
     Map correct = new HashMap();
-    correct.put("x-smtpapi", "{\"to\":[\"email@example.com\"]}");
     correct.put("from", fromaddress);
-    correct.put("to", fromaddress);
+    correct.put("to[0]", address);
 
     assertEquals(correct, email.toWebFormat());
 
@@ -64,7 +54,6 @@ public class SendGridTest {
 
     Map correct = new HashMap();
     correct.put("from", address);
-    correct.put("to", address);
 
     assertEquals(correct, email.toWebFormat());
   }  
@@ -182,5 +171,16 @@ public class SendGridTest {
     SendGrid.Response resp = sendgrid.send(email);
 
     assertEquals("{\"message\":\"error\",\"errors\":[\"Bad username / password\"]}", resp.getMessage());
+  }
+
+
+  @Test public void canAddRecipientToSmtpApi() {
+      email = new SendGrid.Email();
+      email.addSmtpApiTo("email@example.com");
+
+      Map correct = new HashMap();
+      correct.put("x-smtpapi", "{\"to\":[\"email@example.com\"]}");
+
+      assertEquals(correct, email.toWebFormat());
   }
 }


### PR DESCRIPTION
I ran into a problem with sendgrid not sending BCC emails when the x-smtpapi header is used for the 'to' recipients.  

This change puts recipients added via addTo() to the 'to' parameter and adds a new method to allow the caller to choose to add recipients to the x-smtpapi parameter.

For the caller to get the old default behavior where the 'from' address is used for the 'to' parameter and recipients are added to x-smtpapi the caller would do:

email = new SendGrid.Email();
email.addTo(fromAddress);
email.addSmtpApiTo(toAddress);
