### PR TITLE
Add skyscreamer/JSONassert dependency to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             <artifactId>json</artifactId>
             <version>20140107</version>
         </dependency>
+	<dependency>
+	    <groupId>org.skyscreamer</groupId>
+	    <artifactId>jsonassert</artifactId>
+	    <version>1.2.3</version>
+	<scope>test</scope>
+	</dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit-dep</artifactId>


### PR DESCRIPTION
This was causing the build to fail unless dependency was manually added to pom.xml or unless the skyscreamer/JSONassert JAR was downloaded and added to the classpath.