### PR TITLE
Fixed bug in addSubstitutions and added addSubstitution and setSubstitutions calls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,18 @@ email.addSubstitution("key", "value");
 JSONObject subs = header.getSubstitutions();
 ```
 
+#### addSubstitutions
+
+```java
+email.addSubstititions("key", new String[]{"value1", "value2"});
+
+JSONObject subs = header.getSubstititons();
+```
+
 #### setSubstitutions
 
 ```java
-email.setSubstitutions("key", new String[]{"value1", "value2"});
+email.setSubstitutions(new JSONObject("JSON Object"));
 
 JSONObject subs = header.getSubstitutions();
 ```

--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -351,8 +351,18 @@ public class SendGrid {
             return this.html;
         }
 
-        public Email addSubstitution(String key, String[] val) {
+        public Email addSubstitution(String key, String val) {
+            this.smtpapi.addSubstitution(key, val);
+            return this;
+        }
+
+        public Email addSubstitutions(String key, String[] val) {
             this.smtpapi.addSubstitutions(key, val);
+            return this;
+        }
+
+        public Email setSubstitutions(JSONObject subs) {
+            this.smtpapi.setSubstitutions(subs);
             return this;
         }
 


### PR DESCRIPTION
There is a bug in the addSubstitution method.  It attempts to call the addSubstitutions (plural) SMTPAPI method which is incorrect.  
* Fixed the addSubstitution method to call the appropriate SMTPAPI method.
* Implemented the appropriate addSubstitutions method.
* Implemented the setSubstitutions method (taking in a JSONObject which is expected by the SMTPAPI.)
* Updated documentation to properly reflect fixes and new methods.