### PR TITLE
Backport sendgrid-java to utilize Websphere era HTTPClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Java module allows you to quickly and easily send emails through SendGrid using Java.
 
-[![BuildStatus](https://travis-ci.org/sendgrid/sendgrid-java.svg?branch=master)](https://travis-ci.org/sendgrid/sendgrid-java)
+[![BuildStatus](https://travis-ci.org/sftwninja/sendgrid-java.svg?branch=master)](https://travis-ci.org/sftwninja/sendgrid-java)
 [![BuildStatus](https://maven-badges.herokuapp.com/maven-central/com.sendgrid/sendgrid-java/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.sendgrid/sendgrid-java)
 
 ### Warning

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,9 @@ buildscript {
 
 dependencies {
   compile 'com.sendgrid:smtpapi-java:1.2.0'
-  compile 'org.apache.httpcomponents:httpcore:4.3.2'
-  compile 'org.apache.httpcomponents:httpclient:4.3.4'
-  compile 'org.apache.httpcomponents:httpmime:4.3.4'
+  compile 'org.apache.httpcomponents:httpcore:4.2.4'
+  compile 'org.apache.httpcomponents:httpclient:4.2.4'
+  compile 'org.apache.httpcomponents:httpmime:4.2.4'
   compile 'org.json:json:20140107'
   testCompile group: 'junit', name: 'junit', version: '4.12'
   testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.2.3'

--- a/pom.xml
+++ b/pom.xml
@@ -95,17 +95,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3.2</version>
+            <version>4.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
+            <version>4.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.3.4</version>
+            <version>4.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
Need this because Websphere forces an older version of Apache's HTTP Utilities which the mainline sendgrid-java cannot use.