### PR TITLE
fix missing test dependency in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,5 +118,11 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
I copied the skyscreamer dependency from build.gradle into pom.xml to allow mvn to build