### PR TITLE
Update java-http-client dependency to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
 }
 
 dependencies {
-  compile 'com.sendgrid:java-http-client:2.3.4'
+  compile 'com.sendgrid:java-http-client:3.0.0'
   compile 'com.fasterxml.jackson.core:jackson-core:2.5.3'
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.5.3'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.5.3'

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sendgrid</groupId>
             <artifactId>java-http-client</artifactId>
-            <version>2.3.4</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -109,7 +109,7 @@ public class SendGrid {
       req.addHeader(headerKey, this.requestHeaders.get(headerKey));
     }
     for (String queryParamKey : request.getQueryParams().keySet()) {
-      req.addHeader(queryParamKey, request.getQueryParams().get(queryParamKey));
+      req.addQueryParam(queryParamKey, request.getQueryParams().get(queryParamKey));
     }
 
     return makeCall(req);

--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -101,12 +101,16 @@ public class SendGrid {
     */
   public Response api(Request request) throws IOException {
     Request req = new Request();
-    req.method = request.method;
-    req.baseUri = this.host;
-    req.endpoint = "/" + version + "/" + request.endpoint;
-    req.body = request.body;
-    req.headers = this.requestHeaders;
-    req.queryParams = request.queryParams;
+    req.setMethod(request.getMethod());
+    req.setBaseUri(this.host);
+    req.setEndpoint("/" + version + "/" + request.getEndpoint());
+    req.setBody(request.getBody());
+    for (String headerKey : this.requestHeaders.keySet()) {
+      req.addHeader(headerKey, this.requestHeaders.get(headerKey));
+    }
+    for (String queryParamKey : request.getQueryParams().keySet()) {
+      req.addHeader(queryParamKey, request.getQueryParams().get(queryParamKey));
+    }
 
     return makeCall(req);
   }

--- a/src/test/java/com/sendgrid/SendGridTest.java
+++ b/src/test/java/com/sendgrid/SendGridTest.java
@@ -82,11 +82,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "access_settings/activity";
+    request.setMethod(Method.GET);
+    request.setEndpoint("access_settings/activity");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -104,9 +104,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "access_settings/whitelist";
-    request.body = "{\"ips\":[{\"ip\":\"192.168.1.1\"},{\"ip\":\"192.*.*.*\"},{\"ip\":\"192.168.1.3/32\"}]}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("access_settings/whitelist");
+    request.setBody("{\"ips\":[{\"ip\":\"192.168.1.1\"},{\"ip\":\"192.*.*.*\"},{\"ip\":\"192.168.1.3/32\"}]}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -124,8 +124,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "access_settings/whitelist";
+    request.setMethod(Method.GET);
+    request.setEndpoint("access_settings/whitelist");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -143,9 +143,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "access_settings/whitelist";
-    request.body = "{\"ids\":[1,2,3]}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("access_settings/whitelist");
+    request.setBody("{\"ids\":[1,2,3]}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -163,8 +163,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "access_settings/whitelist/{rule_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("access_settings/whitelist/{rule_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -182,8 +182,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "access_settings/whitelist/{rule_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("access_settings/whitelist/{rule_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -201,9 +201,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "alerts";
-    request.body = "{\"type\":\"stats_notification\",\"frequency\":\"daily\",\"email_to\":\"example@example.com\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("alerts");
+    request.setBody("{\"type\":\"stats_notification\",\"frequency\":\"daily\",\"email_to\":\"example@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -221,8 +221,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "alerts";
+    request.setMethod(Method.GET);
+    request.setEndpoint("alerts");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -240,9 +240,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "alerts/{alert_id}";
-    request.body = "{\"email_to\":\"example@example.com\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("alerts/{alert_id}");
+    request.setBody("{\"email_to\":\"example@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -260,8 +260,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "alerts/{alert_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("alerts/{alert_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -279,8 +279,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "alerts/{alert_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("alerts/{alert_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -298,9 +298,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "api_keys";
-    request.body = "{\"sample\":\"data\",\"scopes\":[\"mail.send\",\"alerts.create\",\"alerts.read\"],\"name\":\"My API Key\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("api_keys");
+    request.setBody("{\"sample\":\"data\",\"scopes\":[\"mail.send\",\"alerts.create\",\"alerts.read\"],\"name\":\"My API Key\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -318,11 +318,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "api_keys";
+    request.setMethod(Method.GET);
+    request.setEndpoint("api_keys");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -340,9 +340,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "api_keys/{api_key_id}";
-    request.body = "{\"scopes\":[\"user.profile.read\",\"user.profile.update\"],\"name\":\"A New Hope\"}";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("api_keys/{api_key_id}");
+    request.setBody("{\"scopes\":[\"user.profile.read\",\"user.profile.update\"],\"name\":\"A New Hope\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -360,9 +360,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "api_keys/{api_key_id}";
-    request.body = "{\"name\":\"A New Hope\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("api_keys/{api_key_id}");
+    request.setBody("{\"name\":\"A New Hope\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -380,8 +380,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "api_keys/{api_key_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("api_keys/{api_key_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -399,8 +399,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "api_keys/{api_key_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("api_keys/{api_key_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -418,9 +418,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "asm/groups";
-    request.body = "{\"is_default\":true,\"description\":\"Suggestions for products our users might like.\",\"name\":\"Product Suggestions\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("asm/groups");
+    request.setBody("{\"is_default\":true,\"description\":\"Suggestions for products our users might like.\",\"name\":\"Product Suggestions\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -438,11 +438,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "asm/groups";
+    request.setMethod(Method.GET);
+    request.setEndpoint("asm/groups");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("id", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -460,9 +460,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "asm/groups/{group_id}";
-    request.body = "{\"description\":\"Suggestions for items our users might like.\",\"name\":\"Item Suggestions\",\"id\":103}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("asm/groups/{group_id}");
+    request.setBody("{\"description\":\"Suggestions for items our users might like.\",\"name\":\"Item Suggestions\",\"id\":103}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -480,8 +480,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "asm/groups/{group_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("asm/groups/{group_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -499,8 +499,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "asm/groups/{group_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("asm/groups/{group_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -518,9 +518,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "asm/groups/{group_id}/suppressions";
-    request.body = "{\"recipient_emails\":[\"test1@example.com\",\"test2@example.com\"]}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("asm/groups/{group_id}/suppressions");
+    request.setBody("{\"recipient_emails\":[\"test1@example.com\",\"test2@example.com\"]}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -538,8 +538,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "asm/groups/{group_id}/suppressions";
+    request.setMethod(Method.GET);
+    request.setEndpoint("asm/groups/{group_id}/suppressions");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -557,9 +557,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "asm/groups/{group_id}/suppressions/search";
-    request.body = "{\"recipient_emails\":[\"exists1@example.com\",\"exists2@example.com\",\"doesnotexists@example.com\"]}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("asm/groups/{group_id}/suppressions/search");
+    request.setBody("{\"recipient_emails\":[\"exists1@example.com\",\"exists2@example.com\",\"doesnotexists@example.com\"]}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -577,8 +577,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "asm/groups/{group_id}/suppressions/{email}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("asm/groups/{group_id}/suppressions/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -596,8 +596,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "asm/suppressions";
+    request.setMethod(Method.GET);
+    request.setEndpoint("asm/suppressions");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -615,9 +615,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "asm/suppressions/global";
-    request.body = "{\"recipient_emails\":[\"test1@example.com\",\"test2@example.com\"]}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("asm/suppressions/global");
+    request.setBody("{\"recipient_emails\":[\"test1@example.com\",\"test2@example.com\"]}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -635,8 +635,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "asm/suppressions/global/{email}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("asm/suppressions/global/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -654,8 +654,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "asm/suppressions/global/{email}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("asm/suppressions/global/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -673,8 +673,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "asm/suppressions/{email}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("asm/suppressions/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -692,8 +692,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "browsers/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("browsers/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("aggregated_by", "day");
@@ -701,7 +701,7 @@ public class SendGridTest {
       queryParams.put("limit", "test_string");
       queryParams.put("offset", "test_string");
       queryParams.put("start_date", "2016-01-01");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -719,9 +719,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "campaigns";
-    request.body = "{\"custom_unsubscribe_url\":\"\",\"html_content\":\"<html><head><title></title></head><body><p>Check out our spring line!</p></body></html>\",\"list_ids\":[110,124],\"sender_id\":124451,\"subject\":\"New Products for Spring!\",\"plain_content\":\"Check out our spring line!\",\"suppression_group_id\":42,\"title\":\"March Newsletter\",\"segment_ids\":[110],\"categories\":[\"spring line\"],\"ip_pool\":\"marketing\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("campaigns");
+    request.setBody("{\"custom_unsubscribe_url\":\"\",\"html_content\":\"<html><head><title></title></head><body><p>Check out our spring line!</p></body></html>\",\"list_ids\":[110,124],\"sender_id\":124451,\"subject\":\"New Products for Spring!\",\"plain_content\":\"Check out our spring line!\",\"suppression_group_id\":42,\"title\":\"March Newsletter\",\"segment_ids\":[110],\"categories\":[\"spring line\"],\"ip_pool\":\"marketing\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -739,12 +739,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "campaigns";
+    request.setMethod(Method.GET);
+    request.setEndpoint("campaigns");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -762,9 +762,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "campaigns/{campaign_id}";
-    request.body = "{\"html_content\":\"<html><head><title></title></head><body><p>Check out our summer line!</p></body></html>\",\"subject\":\"New Products for Summer!\",\"title\":\"May Newsletter\",\"categories\":[\"summer line\"],\"plain_content\":\"Check out our summer line!\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("campaigns/{campaign_id}");
+    request.setBody("{\"html_content\":\"<html><head><title></title></head><body><p>Check out our summer line!</p></body></html>\",\"subject\":\"New Products for Summer!\",\"title\":\"May Newsletter\",\"categories\":[\"summer line\"],\"plain_content\":\"Check out our summer line!\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -782,8 +782,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "campaigns/{campaign_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("campaigns/{campaign_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -801,8 +801,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "campaigns/{campaign_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("campaigns/{campaign_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -820,9 +820,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "campaigns/{campaign_id}/schedules";
-    request.body = "{\"send_at\":1489451436}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("campaigns/{campaign_id}/schedules");
+    request.setBody("{\"send_at\":1489451436}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -840,9 +840,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "campaigns/{campaign_id}/schedules";
-    request.body = "{\"send_at\":1489771528}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("campaigns/{campaign_id}/schedules");
+    request.setBody("{\"send_at\":1489771528}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -860,8 +860,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "campaigns/{campaign_id}/schedules";
+    request.setMethod(Method.GET);
+    request.setEndpoint("campaigns/{campaign_id}/schedules");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -879,8 +879,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "campaigns/{campaign_id}/schedules";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("campaigns/{campaign_id}/schedules");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -898,8 +898,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "campaigns/{campaign_id}/schedules/now";
+    request.setMethod(Method.POST);
+    request.setEndpoint("campaigns/{campaign_id}/schedules/now");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -917,9 +917,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "campaigns/{campaign_id}/schedules/test";
-    request.body = "{\"to\":\"your.email@example.com\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("campaigns/{campaign_id}/schedules/test");
+    request.setBody("{\"to\":\"your.email@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -937,13 +937,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "categories";
+    request.setMethod(Method.GET);
+    request.setEndpoint("categories");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("category", "test_string");
       queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -961,8 +961,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "categories/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("categories/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("aggregated_by", "day");
@@ -970,7 +970,7 @@ public class SendGridTest {
       queryParams.put("offset", "1");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("categories", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -988,8 +988,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "categories/stats/sums";
+    request.setMethod(Method.GET);
+    request.setEndpoint("categories/stats/sums");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("aggregated_by", "day");
@@ -998,7 +998,7 @@ public class SendGridTest {
       queryParams.put("offset", "1");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("sort_by_direction", "asc");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1016,13 +1016,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "clients/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("clients/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("aggregated_by", "day");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("end_date", "2016-04-01");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1040,13 +1040,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "clients/{client_type}/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("clients/{client_type}/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("aggregated_by", "day");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("end_date", "2016-04-01");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1064,9 +1064,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "contactdb/custom_fields";
-    request.body = "{\"type\":\"text\",\"name\":\"pet\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("contactdb/custom_fields");
+    request.setBody("{\"type\":\"text\",\"name\":\"pet\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1084,8 +1084,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/custom_fields";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/custom_fields");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1103,8 +1103,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/custom_fields/{custom_field_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/custom_fields/{custom_field_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1122,8 +1122,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "202");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/custom_fields/{custom_field_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/custom_fields/{custom_field_id}");
     Response response = sg.api(request);
     Assert.assertEquals(202, response.statusCode);
   }
@@ -1141,9 +1141,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "contactdb/lists";
-    request.body = "{\"name\":\"your list name\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("contactdb/lists");
+    request.setBody("{\"name\":\"your list name\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1161,8 +1161,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/lists";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/lists");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1180,9 +1180,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/lists";
-    request.body = "[1,2,3,4]";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/lists");
+    request.setBody("[1,2,3,4]");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -1200,12 +1200,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "contactdb/lists/{list_id}";
-    request.body = "{\"name\":\"newlistname\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("contactdb/lists/{list_id}");
+    request.setBody("{\"name\":\"newlistname\"}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("list_id", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1223,11 +1223,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/lists/{list_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/lists/{list_id}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("list_id", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1245,11 +1245,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "202");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/lists/{list_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/lists/{list_id}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("delete_contacts", "true");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(202, response.statusCode);
   }
@@ -1267,9 +1267,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "contactdb/lists/{list_id}/recipients";
-    request.body = "[\"recipient_id1\",\"recipient_id2\"]";
+    request.setMethod(Method.POST);
+    request.setEndpoint("contactdb/lists/{list_id}/recipients");
+    request.setBody("[\"recipient_id1\",\"recipient_id2\"]");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1287,13 +1287,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/lists/{list_id}/recipients";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/lists/{list_id}/recipients");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("page", "1");
       queryParams.put("page_size", "1");
       queryParams.put("list_id", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1311,8 +1311,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "contactdb/lists/{list_id}/recipients/{recipient_id}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("contactdb/lists/{list_id}/recipients/{recipient_id}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1330,12 +1330,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/lists/{list_id}/recipients/{recipient_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/lists/{list_id}/recipients/{recipient_id}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("recipient_id", "1");
       queryParams.put("list_id", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -1353,9 +1353,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "contactdb/recipients";
-    request.body = "[{\"first_name\":\"Guy\",\"last_name\":\"Jones\",\"email\":\"jones@example.com\"}]";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("contactdb/recipients");
+    request.setBody("[{\"first_name\":\"Guy\",\"last_name\":\"Jones\",\"email\":\"jones@example.com\"}]");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1373,9 +1373,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "contactdb/recipients";
-    request.body = "[{\"age\":25,\"last_name\":\"User\",\"email\":\"example@example.com\",\"first_name\":\"\"},{\"age\":25,\"last_name\":\"User\",\"email\":\"example2@example.com\",\"first_name\":\"Example\"}]";
+    request.setMethod(Method.POST);
+    request.setEndpoint("contactdb/recipients");
+    request.setBody("[{\"age\":25,\"last_name\":\"User\",\"email\":\"example@example.com\",\"first_name\":\"\"},{\"age\":25,\"last_name\":\"User\",\"email\":\"example2@example.com\",\"first_name\":\"Example\"}]");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1393,12 +1393,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/recipients";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/recipients");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("page", "1");
       queryParams.put("page_size", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1416,9 +1416,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/recipients";
-    request.body = "[\"recipient_id1\",\"recipient_id2\"]";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/recipients");
+    request.setBody("[\"recipient_id1\",\"recipient_id2\"]");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1436,8 +1436,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/recipients/billable_count";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/recipients/billable_count");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1455,8 +1455,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/recipients/count";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/recipients/count");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1474,11 +1474,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/recipients/search";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/recipients/search");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("{field_name}", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1496,8 +1496,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/recipients/{recipient_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/recipients/{recipient_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1515,8 +1515,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/recipients/{recipient_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/recipients/{recipient_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -1534,8 +1534,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/recipients/{recipient_id}/lists";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/recipients/{recipient_id}/lists");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1553,8 +1553,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/reserved_fields";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/reserved_fields");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1572,9 +1572,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "contactdb/segments";
-    request.body = "{\"conditions\":[{\"operator\":\"eq\",\"field\":\"last_name\",\"and_or\":\"\",\"value\":\"Miller\"},{\"operator\":\"gt\",\"field\":\"last_clicked\",\"and_or\":\"and\",\"value\":\"01/02/2015\"},{\"operator\":\"eq\",\"field\":\"clicks.campaign_identifier\",\"and_or\":\"or\",\"value\":\"513\"}],\"name\":\"Last Name Miller\",\"list_id\":4}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("contactdb/segments");
+    request.setBody("{\"conditions\":[{\"operator\":\"eq\",\"field\":\"last_name\",\"and_or\":\"\",\"value\":\"Miller\"},{\"operator\":\"gt\",\"field\":\"last_clicked\",\"and_or\":\"and\",\"value\":\"01/02/2015\"},{\"operator\":\"eq\",\"field\":\"clicks.campaign_identifier\",\"and_or\":\"or\",\"value\":\"513\"}],\"name\":\"Last Name Miller\",\"list_id\":4}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1592,8 +1592,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/segments";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/segments");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1611,12 +1611,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "contactdb/segments/{segment_id}";
-    request.body = "{\"conditions\":[{\"operator\":\"eq\",\"field\":\"last_name\",\"and_or\":\"\",\"value\":\"Miller\"}],\"name\":\"The Millers\",\"list_id\":5}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("contactdb/segments/{segment_id}");
+    request.setBody("{\"conditions\":[{\"operator\":\"eq\",\"field\":\"last_name\",\"and_or\":\"\",\"value\":\"Miller\"}],\"name\":\"The Millers\",\"list_id\":5}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("segment_id", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1634,11 +1634,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/segments/{segment_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/segments/{segment_id}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("segment_id", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1656,11 +1656,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "contactdb/segments/{segment_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("contactdb/segments/{segment_id}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("delete_contacts", "true");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -1678,12 +1678,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "contactdb/segments/{segment_id}/recipients";
+    request.setMethod(Method.GET);
+    request.setEndpoint("contactdb/segments/{segment_id}/recipients");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("page", "1");
       queryParams.put("page_size", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1701,15 +1701,15 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "devices/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("devices/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("aggregated_by", "day");
       queryParams.put("limit", "1");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("end_date", "2016-04-01");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1727,8 +1727,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "geo/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("geo/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("country", "US");
@@ -1736,7 +1736,7 @@ public class SendGridTest {
       queryParams.put("limit", "1");
       queryParams.put("offset", "1");
       queryParams.put("start_date", "2016-01-01");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1754,15 +1754,15 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("subuser", "test_string");
       queryParams.put("ip", "test_string");
       queryParams.put("limit", "1");
       queryParams.put("exclude_whitelabels", "true");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1780,8 +1780,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips/assigned";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips/assigned");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1799,9 +1799,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "ips/pools";
-    request.body = "{\"name\":\"marketing\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("ips/pools");
+    request.setBody("{\"name\":\"marketing\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1819,8 +1819,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips/pools";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips/pools");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1838,9 +1838,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "ips/pools/{pool_name}";
-    request.body = "{\"name\":\"new_pool_name\"}";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("ips/pools/{pool_name}");
+    request.setBody("{\"name\":\"new_pool_name\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1858,8 +1858,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips/pools/{pool_name}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips/pools/{pool_name}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1877,8 +1877,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "ips/pools/{pool_name}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("ips/pools/{pool_name}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -1896,9 +1896,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "ips/pools/{pool_name}/ips";
-    request.body = "{\"ip\":\"0.0.0.0\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("ips/pools/{pool_name}/ips");
+    request.setBody("{\"ip\":\"0.0.0.0\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -1916,8 +1916,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "ips/pools/{pool_name}/ips/{ip}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("ips/pools/{pool_name}/ips/{ip}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -1935,9 +1935,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "ips/warmup";
-    request.body = "{\"ip\":\"0.0.0.0\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("ips/warmup");
+    request.setBody("{\"ip\":\"0.0.0.0\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1955,8 +1955,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips/warmup";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips/warmup");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1974,8 +1974,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips/warmup/{ip_address}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips/warmup/{ip_address}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -1993,8 +1993,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "ips/warmup/{ip_address}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("ips/warmup/{ip_address}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -2012,8 +2012,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "ips/{ip_address}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("ips/{ip_address}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2031,8 +2031,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "mail/batch";
+    request.setMethod(Method.POST);
+    request.setEndpoint("mail/batch");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -2050,8 +2050,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail/batch/{batch_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail/batch/{batch_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2069,9 +2069,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "202");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "mail/send";
-    request.body = "{\"custom_args\":{\"New Argument 1\":\"New Value 1\",\"activationAttempt\":\"1\",\"customerAccountNumber\":\"[CUSTOMER ACCOUNT NUMBER GOES HERE]\"},\"from\":{\"email\":\"sam.smith@example.com\",\"name\":\"Sam Smith\"},\"attachments\":[{\"name\":\"file1\",\"filename\":\"file1.jpg\",\"content\":\"[BASE64 encoded content block here]\",\"disposition\":\"inline\",\"content_id\":\"ii_139db99fdb5c3704\",\"type\":\"jpg\"}],\"personalizations\":[{\"to\":[{\"email\":\"john.doe@example.com\",\"name\":\"John Doe\"}],\"cc\":[{\"email\":\"jane.doe@example.com\",\"name\":\"Jane Doe\"}],\"bcc\":[{\"email\":\"sam.doe@example.com\",\"name\":\"Sam Doe\"}],\"custom_args\":{\"New Argument 1\":\"New Value 1\",\"activationAttempt\":\"1\",\"customerAccountNumber\":\"[CUSTOMER ACCOUNT NUMBER GOES HERE]\"},\"headers\":{\"X-Accept-Language\":\"en\",\"X-Mailer\":\"MyApp\"},\"send_at\":1409348513,\"substitutions\":{\"type\":\"object\",\"id\":\"substitutions\"},\"subject\":\"Hello, World!\"}],\"subject\":\"Hello, World!\",\"ip_pool_name\":\"[YOUR POOL NAME GOES HERE]\",\"content\":[{\"type\":\"text/html\",\"value\":\"<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>\"}],\"headers\":{},\"asm\":{\"groups_to_display\":[1,2,3],\"group_id\":1},\"batch_id\":\"[YOUR BATCH ID GOES HERE]\",\"tracking_settings\":{\"subscription_tracking\":{\"text\":\"If you would like to unsubscribe and stop receiveing these emails <% click here %>.\",\"enable\":true,\"html\":\"If you would like to unsubscribe and stop receiving these emails <% clickhere %>.\",\"substitution_tag\":\"<%click here%>\"},\"open_tracking\":{\"enable\":true,\"substitution_tag\":\"%opentrack\"},\"click_tracking\":{\"enable\":true,\"enable_text\":true},\"ganalytics\":{\"utm_campaign\":\"[NAME OF YOUR REFERRER SOURCE]\",\"enable\":true,\"utm_name\":\"[NAME OF YOUR CAMPAIGN]\",\"utm_term\":\"[IDENTIFY PAID KEYWORDS HERE]\",\"utm_content\":\"[USE THIS SPACE TO DIFFERENTIATE YOUR EMAIL FROM ADS]\",\"utm_medium\":\"[NAME OF YOUR MARKETING MEDIUM e.g. email]\"}},\"mail_settings\":{\"footer\":{\"text\":\"Thanks,/n The SendGrid Team\",\"enable\":true,\"html\":\"<p>Thanks</br>The SendGrid Team</p>\"},\"spam_check\":{\"threshold\":3,\"post_to_url\":\"http://example.com/compliance\",\"enable\":true},\"bypass_list_management\":{\"enable\":true},\"sandbox_mode\":{\"enable\":false},\"bcc\":{\"enable\":true,\"email\":\"ben.doe@example.com\"}},\"reply_to\":{\"email\":\"sam.smith@example.com\",\"name\":\"Sam Smith\"},\"sections\":{\"section\":{\":sectionName2\":\"section 2 text\",\":sectionName1\":\"section 1 text\"}},\"template_id\":\"[YOUR TEMPLATE ID GOES HERE]\",\"categories\":[\"category1\",\"category2\"],\"send_at\":1409348513}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("mail/send");
+    request.setBody("{\"custom_args\":{\"New Argument 1\":\"New Value 1\",\"activationAttempt\":\"1\",\"customerAccountNumber\":\"[CUSTOMER ACCOUNT NUMBER GOES HERE]\"},\"from\":{\"email\":\"sam.smith@example.com\",\"name\":\"Sam Smith\"},\"attachments\":[{\"name\":\"file1\",\"filename\":\"file1.jpg\",\"content\":\"[BASE64 encoded content block here]\",\"disposition\":\"inline\",\"content_id\":\"ii_139db99fdb5c3704\",\"type\":\"jpg\"}],\"personalizations\":[{\"to\":[{\"email\":\"john.doe@example.com\",\"name\":\"John Doe\"}],\"cc\":[{\"email\":\"jane.doe@example.com\",\"name\":\"Jane Doe\"}],\"bcc\":[{\"email\":\"sam.doe@example.com\",\"name\":\"Sam Doe\"}],\"custom_args\":{\"New Argument 1\":\"New Value 1\",\"activationAttempt\":\"1\",\"customerAccountNumber\":\"[CUSTOMER ACCOUNT NUMBER GOES HERE]\"},\"headers\":{\"X-Accept-Language\":\"en\",\"X-Mailer\":\"MyApp\"},\"send_at\":1409348513,\"substitutions\":{\"type\":\"object\",\"id\":\"substitutions\"},\"subject\":\"Hello, World!\"}],\"subject\":\"Hello, World!\",\"ip_pool_name\":\"[YOUR POOL NAME GOES HERE]\",\"content\":[{\"type\":\"text/html\",\"value\":\"<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>\"}],\"headers\":{},\"asm\":{\"groups_to_display\":[1,2,3],\"group_id\":1},\"batch_id\":\"[YOUR BATCH ID GOES HERE]\",\"tracking_settings\":{\"subscription_tracking\":{\"text\":\"If you would like to unsubscribe and stop receiveing these emails <% click here %>.\",\"enable\":true,\"html\":\"If you would like to unsubscribe and stop receiving these emails <% clickhere %>.\",\"substitution_tag\":\"<%click here%>\"},\"open_tracking\":{\"enable\":true,\"substitution_tag\":\"%opentrack\"},\"click_tracking\":{\"enable\":true,\"enable_text\":true},\"ganalytics\":{\"utm_campaign\":\"[NAME OF YOUR REFERRER SOURCE]\",\"enable\":true,\"utm_name\":\"[NAME OF YOUR CAMPAIGN]\",\"utm_term\":\"[IDENTIFY PAID KEYWORDS HERE]\",\"utm_content\":\"[USE THIS SPACE TO DIFFERENTIATE YOUR EMAIL FROM ADS]\",\"utm_medium\":\"[NAME OF YOUR MARKETING MEDIUM e.g. email]\"}},\"mail_settings\":{\"footer\":{\"text\":\"Thanks,/n The SendGrid Team\",\"enable\":true,\"html\":\"<p>Thanks</br>The SendGrid Team</p>\"},\"spam_check\":{\"threshold\":3,\"post_to_url\":\"http://example.com/compliance\",\"enable\":true},\"bypass_list_management\":{\"enable\":true},\"sandbox_mode\":{\"enable\":false},\"bcc\":{\"enable\":true,\"email\":\"ben.doe@example.com\"}},\"reply_to\":{\"email\":\"sam.smith@example.com\",\"name\":\"Sam Smith\"},\"sections\":{\"section\":{\":sectionName2\":\"section 2 text\",\":sectionName1\":\"section 1 text\"}},\"template_id\":\"[YOUR TEMPLATE ID GOES HERE]\",\"categories\":[\"category1\",\"category2\"],\"send_at\":1409348513}");
     Response response = sg.api(request);
     Assert.assertEquals(202, response.statusCode);
   }
@@ -2089,12 +2089,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2112,9 +2112,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/address_whitelist";
-    request.body = "{\"list\":[\"email1@example.com\",\"example.com\"],\"enabled\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/address_whitelist");
+    request.setBody("{\"list\":[\"email1@example.com\",\"example.com\"],\"enabled\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2132,8 +2132,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/address_whitelist";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/address_whitelist");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2151,9 +2151,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/bcc";
-    request.body = "{\"enabled\":false,\"email\":\"email@example.com\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/bcc");
+    request.setBody("{\"enabled\":false,\"email\":\"email@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2171,8 +2171,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/bcc";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/bcc");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2190,9 +2190,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/bounce_purge";
-    request.body = "{\"hard_bounces\":5,\"soft_bounces\":5,\"enabled\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/bounce_purge");
+    request.setBody("{\"hard_bounces\":5,\"soft_bounces\":5,\"enabled\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2210,8 +2210,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/bounce_purge";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/bounce_purge");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2229,9 +2229,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/footer";
-    request.body = "{\"html_content\":\"...\",\"enabled\":true,\"plain_content\":\"...\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/footer");
+    request.setBody("{\"html_content\":\"...\",\"enabled\":true,\"plain_content\":\"...\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2249,8 +2249,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/footer";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/footer");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2268,9 +2268,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/forward_bounce";
-    request.body = "{\"enabled\":true,\"email\":\"example@example.com\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/forward_bounce");
+    request.setBody("{\"enabled\":true,\"email\":\"example@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2288,8 +2288,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/forward_bounce";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/forward_bounce");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2307,9 +2307,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/forward_spam";
-    request.body = "{\"enabled\":false,\"email\":\"\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/forward_spam");
+    request.setBody("{\"enabled\":false,\"email\":\"\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2327,8 +2327,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/forward_spam";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/forward_spam");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2346,9 +2346,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/plain_content";
-    request.body = "{\"enabled\":false}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/plain_content");
+    request.setBody("{\"enabled\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2366,8 +2366,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/plain_content";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/plain_content");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2385,9 +2385,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/spam_check";
-    request.body = "{\"url\":\"url\",\"max_score\":5,\"enabled\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/spam_check");
+    request.setBody("{\"url\":\"url\",\"max_score\":5,\"enabled\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2405,8 +2405,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/spam_check";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/spam_check");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2424,9 +2424,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "mail_settings/template";
-    request.body = "{\"html_content\":\"<% body %>\",\"enabled\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("mail_settings/template");
+    request.setBody("{\"html_content\":\"<% body %>\",\"enabled\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2444,8 +2444,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mail_settings/template";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mail_settings/template");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2463,8 +2463,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "mailbox_providers/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("mailbox_providers/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("mailbox_providers", "test_string");
@@ -2472,7 +2472,7 @@ public class SendGridTest {
       queryParams.put("limit", "1");
       queryParams.put("offset", "1");
       queryParams.put("start_date", "2016-01-01");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2490,12 +2490,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "partner_settings";
+    request.setMethod(Method.GET);
+    request.setEndpoint("partner_settings");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2513,9 +2513,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "partner_settings/new_relic";
-    request.body = "{\"enable_subuser_statistics\":true,\"enabled\":true,\"license_key\":\"\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("partner_settings/new_relic");
+    request.setBody("{\"enable_subuser_statistics\":true,\"enabled\":true,\"license_key\":\"\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2533,8 +2533,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "partner_settings/new_relic";
+    request.setMethod(Method.GET);
+    request.setEndpoint("partner_settings/new_relic");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2552,8 +2552,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "scopes";
+    request.setMethod(Method.GET);
+    request.setEndpoint("scopes");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2571,9 +2571,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "senders";
-    request.body = "{\"city\":\"Denver\",\"from\":{\"email\":\"from@example.com\",\"name\":\"Example INC\"},\"zip\":\"80202\",\"country\":\"United States\",\"state\":\"Colorado\",\"address_2\":\"Apt. 456\",\"address\":\"123 Elm St.\",\"reply_to\":{\"email\":\"replyto@example.com\",\"name\":\"Example INC\"},\"nickname\":\"My Sender ID\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("senders");
+    request.setBody("{\"city\":\"Denver\",\"from\":{\"email\":\"from@example.com\",\"name\":\"Example INC\"},\"zip\":\"80202\",\"country\":\"United States\",\"state\":\"Colorado\",\"address_2\":\"Apt. 456\",\"address\":\"123 Elm St.\",\"reply_to\":{\"email\":\"replyto@example.com\",\"name\":\"Example INC\"},\"nickname\":\"My Sender ID\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -2591,8 +2591,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "senders";
+    request.setMethod(Method.GET);
+    request.setEndpoint("senders");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2610,9 +2610,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "senders/{sender_id}";
-    request.body = "{\"city\":\"Denver\",\"from\":{\"email\":\"from@example.com\",\"name\":\"Example INC\"},\"zip\":\"80202\",\"country\":\"United States\",\"state\":\"Colorado\",\"address_2\":\"Apt. 456\",\"address\":\"123 Elm St.\",\"reply_to\":{\"email\":\"replyto@example.com\",\"name\":\"Example INC\"},\"nickname\":\"My Sender ID\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("senders/{sender_id}");
+    request.setBody("{\"city\":\"Denver\",\"from\":{\"email\":\"from@example.com\",\"name\":\"Example INC\"},\"zip\":\"80202\",\"country\":\"United States\",\"state\":\"Colorado\",\"address_2\":\"Apt. 456\",\"address\":\"123 Elm St.\",\"reply_to\":{\"email\":\"replyto@example.com\",\"name\":\"Example INC\"},\"nickname\":\"My Sender ID\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2630,8 +2630,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "senders/{sender_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("senders/{sender_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2649,8 +2649,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "senders/{sender_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("senders/{sender_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -2668,8 +2668,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "senders/{sender_id}/resend_verification";
+    request.setMethod(Method.POST);
+    request.setEndpoint("senders/{sender_id}/resend_verification");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -2687,15 +2687,15 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("aggregated_by", "day");
       queryParams.put("limit", "1");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("end_date", "2016-04-01");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2713,9 +2713,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "subusers";
-    request.body = "{\"username\":\"John@example.com\",\"ips\":[\"1.1.1.1\",\"2.2.2.2\"],\"password\":\"johns_password\",\"email\":\"John@example.com\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("subusers");
+    request.setBody("{\"username\":\"John@example.com\",\"ips\":[\"1.1.1.1\",\"2.2.2.2\"],\"password\":\"johns_password\",\"email\":\"John@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2733,13 +2733,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("username", "test_string");
       queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2757,11 +2757,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers/reputations";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers/reputations");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("usernames", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2779,8 +2779,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("aggregated_by", "day");
@@ -2788,7 +2788,7 @@ public class SendGridTest {
       queryParams.put("offset", "1");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("subusers", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2806,8 +2806,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers/stats/monthly";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers/stats/monthly");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("subuser", "test_string");
       queryParams.put("limit", "1");
@@ -2815,7 +2815,7 @@ public class SendGridTest {
       queryParams.put("offset", "1");
       queryParams.put("date", "test_string");
       queryParams.put("sort_by_direction", "asc");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2833,8 +2833,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers/stats/sums";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers/stats/sums");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("end_date", "2016-04-01");
       queryParams.put("aggregated_by", "day");
@@ -2843,7 +2843,7 @@ public class SendGridTest {
       queryParams.put("offset", "1");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("sort_by_direction", "asc");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2861,9 +2861,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "subusers/{subuser_name}";
-    request.body = "{\"disabled\":false}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("subusers/{subuser_name}");
+    request.setBody("{\"disabled\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -2881,8 +2881,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "subusers/{subuser_name}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("subusers/{subuser_name}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -2900,9 +2900,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "subusers/{subuser_name}/ips";
-    request.body = "[\"127.0.0.1\"]";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("subusers/{subuser_name}/ips");
+    request.setBody("[\"127.0.0.1\"]");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2920,9 +2920,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "subusers/{subuser_name}/monitor";
-    request.body = "{\"frequency\":500,\"email\":\"example@example.com\"}";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("subusers/{subuser_name}/monitor");
+    request.setBody("{\"frequency\":500,\"email\":\"example@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2940,9 +2940,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "subusers/{subuser_name}/monitor";
-    request.body = "{\"frequency\":50000,\"email\":\"example@example.com\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("subusers/{subuser_name}/monitor");
+    request.setBody("{\"frequency\":50000,\"email\":\"example@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2960,8 +2960,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers/{subuser_name}/monitor";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers/{subuser_name}/monitor");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -2979,8 +2979,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "subusers/{subuser_name}/monitor";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("subusers/{subuser_name}/monitor");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -2998,15 +2998,15 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "subusers/{subuser_name}/stats/monthly";
+    request.setMethod(Method.GET);
+    request.setEndpoint("subusers/{subuser_name}/stats/monthly");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("date", "test_string");
       queryParams.put("sort_by_direction", "asc");
       queryParams.put("limit", "1");
       queryParams.put("sort_by_metric", "test_string");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3024,14 +3024,14 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/blocks";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/blocks");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("start_time", "1");
       queryParams.put("limit", "1");
       queryParams.put("end_time", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3049,9 +3049,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/blocks";
-    request.body = "{\"emails\":[\"example1@example.com\",\"example2@example.com\"],\"delete_all\":false}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/blocks");
+    request.setBody("{\"emails\":[\"example1@example.com\",\"example2@example.com\"],\"delete_all\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3069,8 +3069,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/blocks/{email}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/blocks/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3088,8 +3088,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/blocks/{email}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/blocks/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3107,12 +3107,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/bounces";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/bounces");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("start_time", "1");
       queryParams.put("end_time", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3130,9 +3130,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/bounces";
-    request.body = "{\"emails\":[\"example@example.com\",\"example2@example.com\"],\"delete_all\":true}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/bounces");
+    request.setBody("{\"emails\":[\"example@example.com\",\"example2@example.com\"],\"delete_all\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3150,8 +3150,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/bounces/{email}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/bounces/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3169,11 +3169,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/bounces/{email}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/bounces/{email}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("email_address", "example@example.com");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3191,14 +3191,14 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/invalid_emails";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/invalid_emails");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("start_time", "1");
       queryParams.put("limit", "1");
       queryParams.put("end_time", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3216,9 +3216,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/invalid_emails";
-    request.body = "{\"emails\":[\"example1@example.com\",\"example2@example.com\"],\"delete_all\":false}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/invalid_emails");
+    request.setBody("{\"emails\":[\"example1@example.com\",\"example2@example.com\"],\"delete_all\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3236,8 +3236,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/invalid_emails/{email}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/invalid_emails/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3255,8 +3255,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/invalid_emails/{email}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/invalid_emails/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3274,8 +3274,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/spam_report/{email}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/spam_report/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3293,8 +3293,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/spam_report/{email}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/spam_report/{email}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3312,14 +3312,14 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/spam_reports";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/spam_reports");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("start_time", "1");
       queryParams.put("limit", "1");
       queryParams.put("end_time", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3337,9 +3337,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "suppression/spam_reports";
-    request.body = "{\"emails\":[\"example1@example.com\",\"example2@example.com\"],\"delete_all\":false}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("suppression/spam_reports");
+    request.setBody("{\"emails\":[\"example1@example.com\",\"example2@example.com\"],\"delete_all\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3357,14 +3357,14 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "suppression/unsubscribes";
+    request.setMethod(Method.GET);
+    request.setEndpoint("suppression/unsubscribes");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("start_time", "1");
       queryParams.put("limit", "1");
       queryParams.put("end_time", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3382,9 +3382,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "templates";
-    request.body = "{\"name\":\"example_name\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("templates");
+    request.setBody("{\"name\":\"example_name\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -3402,8 +3402,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "templates";
+    request.setMethod(Method.GET);
+    request.setEndpoint("templates");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3421,9 +3421,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "templates/{template_id}";
-    request.body = "{\"name\":\"new_example_name\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("templates/{template_id}");
+    request.setBody("{\"name\":\"new_example_name\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3441,8 +3441,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "templates/{template_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("templates/{template_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3460,8 +3460,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "templates/{template_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("templates/{template_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3479,9 +3479,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "templates/{template_id}/versions";
-    request.body = "{\"name\":\"example_version_name\",\"html_content\":\"<%body%>\",\"plain_content\":\"<%body%>\",\"active\":1,\"template_id\":\"ddb96bbc-9b92-425e-8979-99464621b543\",\"subject\":\"<%subject%>\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("templates/{template_id}/versions");
+    request.setBody("{\"name\":\"example_version_name\",\"html_content\":\"<%body%>\",\"plain_content\":\"<%body%>\",\"active\":1,\"template_id\":\"ddb96bbc-9b92-425e-8979-99464621b543\",\"subject\":\"<%subject%>\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -3499,9 +3499,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "templates/{template_id}/versions/{version_id}";
-    request.body = "{\"active\":1,\"html_content\":\"<%body%>\",\"subject\":\"<%subject%>\",\"name\":\"updated_example_name\",\"plain_content\":\"<%body%>\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("templates/{template_id}/versions/{version_id}");
+    request.setBody("{\"active\":1,\"html_content\":\"<%body%>\",\"subject\":\"<%subject%>\",\"name\":\"updated_example_name\",\"plain_content\":\"<%body%>\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3519,8 +3519,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "templates/{template_id}/versions/{version_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("templates/{template_id}/versions/{version_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3538,8 +3538,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "templates/{template_id}/versions/{version_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("templates/{template_id}/versions/{version_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3557,8 +3557,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "templates/{template_id}/versions/{version_id}/activate";
+    request.setMethod(Method.POST);
+    request.setEndpoint("templates/{template_id}/versions/{version_id}/activate");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3576,12 +3576,12 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "tracking_settings";
+    request.setMethod(Method.GET);
+    request.setEndpoint("tracking_settings");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3599,9 +3599,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "tracking_settings/click";
-    request.body = "{\"enabled\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("tracking_settings/click");
+    request.setBody("{\"enabled\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3619,8 +3619,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "tracking_settings/click";
+    request.setMethod(Method.GET);
+    request.setEndpoint("tracking_settings/click");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3638,9 +3638,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "tracking_settings/google_analytics";
-    request.body = "{\"utm_campaign\":\"website\",\"utm_term\":\"\",\"utm_content\":\"\",\"enabled\":true,\"utm_source\":\"sendgrid.com\",\"utm_medium\":\"email\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("tracking_settings/google_analytics");
+    request.setBody("{\"utm_campaign\":\"website\",\"utm_term\":\"\",\"utm_content\":\"\",\"enabled\":true,\"utm_source\":\"sendgrid.com\",\"utm_medium\":\"email\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3658,8 +3658,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "tracking_settings/google_analytics";
+    request.setMethod(Method.GET);
+    request.setEndpoint("tracking_settings/google_analytics");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3677,9 +3677,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "tracking_settings/open";
-    request.body = "{\"enabled\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("tracking_settings/open");
+    request.setBody("{\"enabled\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3697,8 +3697,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "tracking_settings/open";
+    request.setMethod(Method.GET);
+    request.setEndpoint("tracking_settings/open");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3716,9 +3716,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "tracking_settings/subscription";
-    request.body = "{\"url\":\"url\",\"html_content\":\"html content\",\"enabled\":true,\"landing\":\"landing page html\",\"replace\":\"replacement tag\",\"plain_content\":\"text content\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("tracking_settings/subscription");
+    request.setBody("{\"url\":\"url\",\"html_content\":\"html content\",\"enabled\":true,\"landing\":\"landing page html\",\"replace\":\"replacement tag\",\"plain_content\":\"text content\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3736,8 +3736,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "tracking_settings/subscription";
+    request.setMethod(Method.GET);
+    request.setEndpoint("tracking_settings/subscription");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3755,8 +3755,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/account";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/account");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3774,8 +3774,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/credits";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/credits");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3793,9 +3793,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "user/email";
-    request.body = "{\"email\":\"example@example.com\"}";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("user/email");
+    request.setBody("{\"email\":\"example@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3813,8 +3813,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/email";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/email");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3832,9 +3832,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "user/password";
-    request.body = "{\"new_password\":\"new_password\",\"old_password\":\"old_password\"}";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("user/password");
+    request.setBody("{\"new_password\":\"new_password\",\"old_password\":\"old_password\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3852,9 +3852,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "user/profile";
-    request.body = "{\"city\":\"Orange\",\"first_name\":\"Example\",\"last_name\":\"User\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("user/profile");
+    request.setBody("{\"city\":\"Orange\",\"first_name\":\"Example\",\"last_name\":\"User\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3872,8 +3872,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/profile";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/profile");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3891,9 +3891,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "user/scheduled_sends";
-    request.body = "{\"batch_id\":\"YOUR_BATCH_ID\",\"status\":\"pause\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("user/scheduled_sends");
+    request.setBody("{\"batch_id\":\"YOUR_BATCH_ID\",\"status\":\"pause\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -3911,8 +3911,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/scheduled_sends";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/scheduled_sends");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3930,9 +3930,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "user/scheduled_sends/{batch_id}";
-    request.body = "{\"status\":\"pause\"}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("user/scheduled_sends/{batch_id}");
+    request.setBody("{\"status\":\"pause\"}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3950,8 +3950,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/scheduled_sends/{batch_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/scheduled_sends/{batch_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -3969,8 +3969,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "user/scheduled_sends/{batch_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("user/scheduled_sends/{batch_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -3988,9 +3988,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "user/settings/enforced_tls";
-    request.body = "{\"require_tls\":true,\"require_valid_cert\":false}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("user/settings/enforced_tls");
+    request.setBody("{\"require_tls\":true,\"require_valid_cert\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4008,8 +4008,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/settings/enforced_tls";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/settings/enforced_tls");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4027,9 +4027,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PUT;
-    request.endpoint = "user/username";
-    request.body = "{\"username\":\"test_username\"}";
+    request.setMethod(Method.PUT);
+    request.setEndpoint("user/username");
+    request.setBody("{\"username\":\"test_username\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4047,8 +4047,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/username";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/username");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4066,9 +4066,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "user/webhooks/event/settings";
-    request.body = "{\"group_resubscribe\":true,\"delivered\":true,\"group_unsubscribe\":true,\"spam_report\":true,\"url\":\"url\",\"enabled\":true,\"bounce\":true,\"deferred\":true,\"unsubscribe\":true,\"dropped\":true,\"open\":true,\"click\":true,\"processed\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("user/webhooks/event/settings");
+    request.setBody("{\"group_resubscribe\":true,\"delivered\":true,\"group_unsubscribe\":true,\"spam_report\":true,\"url\":\"url\",\"enabled\":true,\"bounce\":true,\"deferred\":true,\"unsubscribe\":true,\"dropped\":true,\"open\":true,\"click\":true,\"processed\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4086,8 +4086,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/webhooks/event/settings";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/webhooks/event/settings");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4105,9 +4105,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "user/webhooks/event/test";
-    request.body = "{\"url\":\"url\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("user/webhooks/event/test");
+    request.setBody("{\"url\":\"url\"}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4125,9 +4125,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "user/webhooks/parse/settings";
-    request.body = "{\"url\":\"http://email.myhosthame.com\",\"send_raw\":false,\"hostname\":\"myhostname.com\",\"spam_check\":true}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("user/webhooks/parse/settings");
+    request.setBody("{\"url\":\"http://email.myhosthame.com\",\"send_raw\":false,\"hostname\":\"myhostname.com\",\"spam_check\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -4145,8 +4145,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/webhooks/parse/settings";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/webhooks/parse/settings");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4164,9 +4164,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "user/webhooks/parse/settings/{hostname}";
-    request.body = "{\"url\":\"http://newdomain.com/parse\",\"send_raw\":true,\"spam_check\":false}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("user/webhooks/parse/settings/{hostname}");
+    request.setBody("{\"url\":\"http://newdomain.com/parse\",\"send_raw\":true,\"spam_check\":false}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4184,8 +4184,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/webhooks/parse/settings/{hostname}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/webhooks/parse/settings/{hostname}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4203,8 +4203,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "user/webhooks/parse/settings/{hostname}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("user/webhooks/parse/settings/{hostname}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4222,15 +4222,15 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "user/webhooks/parse/stats";
+    request.setMethod(Method.GET);
+    request.setEndpoint("user/webhooks/parse/stats");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("aggregated_by", "day");
       queryParams.put("limit", "test_string");
       queryParams.put("start_date", "2016-01-01");
       queryParams.put("end_date", "2016-04-01");
       queryParams.put("offset", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4248,9 +4248,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/domains";
-    request.body = "{\"automatic_security\":false,\"username\":\"john@example.com\",\"domain\":\"example.com\",\"default\":true,\"custom_spf\":true,\"ips\":[\"192.168.1.1\",\"192.168.1.2\"],\"subdomain\":\"news\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains");
+    request.setBody("{\"automatic_security\":false,\"username\":\"john@example.com\",\"domain\":\"example.com\",\"default\":true,\"custom_spf\":true,\"ips\":[\"192.168.1.1\",\"192.168.1.2\"],\"subdomain\":\"news\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -4268,15 +4268,15 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/domains";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("username", "test_string");
       queryParams.put("domain", "test_string");
       queryParams.put("exclude_subusers", "true");
       queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4294,8 +4294,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/domains/default";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains/default");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4313,8 +4313,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/domains/subuser";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains/subuser");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4332,8 +4332,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "whitelabel/domains/subuser";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/domains/subuser");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4351,9 +4351,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "whitelabel/domains/{domain_id}";
-    request.body = "{\"default\":false,\"custom_spf\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("whitelabel/domains/{domain_id}");
+    request.setBody("{\"default\":false,\"custom_spf\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4371,8 +4371,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/domains/{domain_id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains/{domain_id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4390,8 +4390,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "whitelabel/domains/{domain_id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/domains/{domain_id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4409,9 +4409,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/domains/{domain_id}/subuser";
-    request.body = "{\"username\":\"jane@example.com\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains/{domain_id}/subuser");
+    request.setBody("{\"username\":\"jane@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -4429,9 +4429,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/domains/{id}/ips";
-    request.body = "{\"ip\":\"192.168.0.1\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains/{id}/ips");
+    request.setBody("{\"ip\":\"192.168.0.1\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4449,8 +4449,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "whitelabel/domains/{id}/ips/{ip}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/domains/{id}/ips/{ip}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4468,8 +4468,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/domains/{id}/validate";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains/{id}/validate");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4487,9 +4487,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/ips";
-    request.body = "{\"ip\":\"192.168.1.1\",\"domain\":\"example.com\",\"subdomain\":\"email\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/ips");
+    request.setBody("{\"ip\":\"192.168.1.1\",\"domain\":\"example.com\",\"subdomain\":\"email\"}");
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -4507,13 +4507,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/ips";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/ips");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("ip", "test_string");
       queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4531,8 +4531,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/ips/{id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/ips/{id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4550,8 +4550,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "whitelabel/ips/{id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/ips/{id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4569,8 +4569,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/ips/{id}/validate";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/ips/{id}/validate");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4588,13 +4588,13 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "201");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/links";
-    request.body = "{\"default\":true,\"domain\":\"example.com\",\"subdomain\":\"mail\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/links");
+    request.setBody("{\"default\":true,\"domain\":\"example.com\",\"subdomain\":\"mail\"}");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
       queryParams.put("offset", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(201, response.statusCode);
   }
@@ -4612,11 +4612,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/links";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("limit", "1");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4634,11 +4634,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/links/default";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links/default");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("domain", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4656,11 +4656,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/links/subuser";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links/subuser");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("username", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4678,11 +4678,11 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "whitelabel/links/subuser";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/links/subuser");
     Map<String,String> queryParams = new HashMap<String, String>();
     queryParams.put("username", "test_string");
-    request.queryParams = queryParams;
+    setQueryParams(request, queryParams);
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4700,9 +4700,9 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.PATCH;
-    request.endpoint = "whitelabel/links/{id}";
-    request.body = "{\"default\":true}";
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("whitelabel/links/{id}");
+    request.setBody("{\"default\":true}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4720,8 +4720,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.GET;
-    request.endpoint = "whitelabel/links/{id}";
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links/{id}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4739,8 +4739,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "204");
 
     Request request = new Request();
-    request.method = Method.DELETE;
-    request.endpoint = "whitelabel/links/{id}";
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/links/{id}");
     Response response = sg.api(request);
     Assert.assertEquals(204, response.statusCode);
   }
@@ -4758,8 +4758,8 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/links/{id}/validate";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/links/{id}/validate");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
   }
@@ -4777,11 +4777,17 @@ public class SendGridTest {
     sg.addRequestHeader("X-Mock", "200");
 
     Request request = new Request();
-    request.method = Method.POST;
-    request.endpoint = "whitelabel/links/{link_id}/subuser";
-    request.body = "{\"username\":\"jane@example.com\"}";
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/links/{link_id}/subuser");
+    request.setBody("{\"username\":\"jane@example.com\"}");
     Response response = sg.api(request);
     Assert.assertEquals(200, response.statusCode);
+  }
+  
+  private void setQueryParams(Request req, Map<String, String> queryParams) {
+    for (String key : queryParams.keySet()) {
+      req.addQueryParam(key, queryParams.get(key));
+    }
   }
 
 }


### PR DESCRIPTION
This commits updates the java-http-client dependency to the latest
version and fixes the compilation errors caused by this update.

This closes #155
