### PR TITLE
Return empty collections in place of nulls

### DIFF
--- a/src/main/java/com/sendgrid/helpers/mail/objects/Personalization.java
+++ b/src/main/java/com/sendgrid/helpers/mail/objects/Personalization.java
@@ -19,9 +19,11 @@ public class Personalization {
   @JsonProperty("substitutions") private Map<String,String> substitutions;
   @JsonProperty("custom_args") private Map<String,String> customArgs;
   @JsonProperty("send_at") private long sendAt;
-
+  
   @JsonProperty("to")
   public List<Email> getTos() {
+    if(tos == null)
+       return new ArrayList<Email>();
     return tos;
   }
 
@@ -39,6 +41,8 @@ public class Personalization {
 
   @JsonProperty("cc")
   public List<Email> getCcs() {
+    if(ccs == null)
+       return new ArrayList<Email>();
     return ccs;
   }
 
@@ -56,6 +60,8 @@ public class Personalization {
 
   @JsonProperty("bcc")
   public List<Email> getBccs() {
+    if(bccs == null)
+       return new ArrayList<Email>();
     return bccs;
   }
 
@@ -82,6 +88,8 @@ public class Personalization {
 
   @JsonProperty("headers")
   public Map<String,String> getHeaders() {
+    if(headers == null)
+       return new HashMap<String, String>();
     return headers;
   }
 
@@ -96,6 +104,8 @@ public class Personalization {
 
   @JsonProperty("substitutions")
   public Map<String,String> getSubstitutions() {
+    if(substitutions == null)
+       return new HashMap<String, String>();
     return substitutions;
   }
 
@@ -110,6 +120,8 @@ public class Personalization {
 
   @JsonProperty("custom_args")
   public Map<String,String> getCustomArgs() {
+    if(customArgs == null)
+       return new HashMap<String, String>();
     return customArgs;
   }
 
@@ -130,4 +142,5 @@ public class Personalization {
   public void setSendAt(long sendAt) {
     this.sendAt = sendAt;
   }
+  
 }

--- a/src/main/java/com/sendgrid/helpers/mail/objects/Personalization.java
+++ b/src/main/java/com/sendgrid/helpers/mail/objects/Personalization.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -23,7 +24,7 @@ public class Personalization {
   @JsonProperty("to")
   public List<Email> getTos() {
     if(tos == null)
-       return new ArrayList<Email>();
+       return Collections.<Email>emptyList();
     return tos;
   }
 
@@ -42,7 +43,7 @@ public class Personalization {
   @JsonProperty("cc")
   public List<Email> getCcs() {
     if(ccs == null)
-       return new ArrayList<Email>();
+       return Collections.<Email>emptyList();
     return ccs;
   }
 
@@ -61,7 +62,7 @@ public class Personalization {
   @JsonProperty("bcc")
   public List<Email> getBccs() {
     if(bccs == null)
-       return new ArrayList<Email>();
+       return Collections.<Email>emptyList();
     return bccs;
   }
 
@@ -89,7 +90,7 @@ public class Personalization {
   @JsonProperty("headers")
   public Map<String,String> getHeaders() {
     if(headers == null)
-       return new HashMap<String, String>();
+       return Collections.<String,String>emptyMap();
     return headers;
   }
 
@@ -105,7 +106,7 @@ public class Personalization {
   @JsonProperty("substitutions")
   public Map<String,String> getSubstitutions() {
     if(substitutions == null)
-       return new HashMap<String, String>();
+       return Collections.<String,String>emptyMap();
     return substitutions;
   }
 
@@ -121,7 +122,7 @@ public class Personalization {
   @JsonProperty("custom_args")
   public Map<String,String> getCustomArgs() {
     if(customArgs == null)
-       return new HashMap<String, String>();
+       return Collections.<String,String>emptyMap();
     return customArgs;
   }
 


### PR DESCRIPTION
When calling a getXyz() method on a Mail object, where xyz is some object implementing Collection, if xyz is null then an empty collection will be returned (currently returns null).