### PR TITLE
Adding Docker support.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM store/oracle/serverjre:8
+
+ENV OAI_SPEC_URL="https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"
+
+RUN yum install -y git 
+
+WORKDIR /root
+
+# install Prism
+ADD https://raw.githubusercontent.com/stoplightio/prism/master/install.sh install.sh
+RUN chmod +x ./install.sh && \
+    ./install.sh && \
+    rm ./install.sh
+
+# set up default sendgrid env
+WORKDIR /root/sources
+RUN git clone https://github.com/sendgrid/sendgrid-java.git
+WORKDIR /root
+RUN ln -s /root/sources/sendgrid-java/sendgrid
+
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["--mock"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+# Supported tags and respective `Dockerfile` links
+ - `v1.0.0`, `latest` [(Dockerfile)](https://github.com/sendgrid/sendgrid-java/blob/master/docker/Dockerfile)
+
+# Quick reference
+Due to Oracle's JDK license, you must build this Docker image using the official Oracle image located in the Docker Store. You will need a Docker store account. Once you have an account, you must accept the Oracle license [here](https://store.docker.com/images/oracle-serverjre-8). On the command line, type `docker login` and provide your credentials. You may then build the image using this command `docker build -t sendgrid/sendgrid-java -f Dockerfile .`
+
+ - **Where to get help:**
+   [Contact SendGrid Support](https://support.sendgrid.com/hc/en-us)
+
+ - **Where to file issues:**
+   https://github.com/sendgrid/sendgrid-java/issues
+
+ - **Where to get more info:**
+   [USAGE.md](https://github.com/sendgrid/sendgrid-java/blob/master/docker/USAGE.md)
+
+ - **Maintained by:**
+   [SendGrid Inc.](https://sendgrid.com)
+
+# Usage examples
+ - Most recent version: `docker run -it sendgrid/sendgrid-java`.
+ - Your own fork:
+   ```sh-session
+   $ git clone https://github.com/you/cool-sendgrid-java.git
+   $ realpath cool-sendgrid-java
+   /path/to/cool-sendgrid-java
+   $ docker run -it -v /path/to/cool-sendgrid-java:/mnt/sendgrid-java sendgrid/sendgrid-java
+   ```
+
+For more detailed information, see [USAGE.md](https://github.com/sendgrid/sendgrid-java/blob/master/docker/USAGE.md).
+
+# About
+
+sendgrid-java is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+
+sendgrid-java is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-java are trademarks of SendGrid, Inc.
+
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)

--- a/docker/USAGE.md
+++ b/docker/USAGE.md
@@ -1,0 +1,35 @@
+You can use Docker to easily try out or test sendgrid-java.
+
+<a name="Quickstart"></a>
+# Quickstart
+
+1. Install Docker on your machine.
+2. If you have not done so, create a Docker Store account [here](https://store.docker.com/signup?next=%2F)
+3. Navigate [here](https://store.docker.com/images/oracle-serverjre-8) and click the "Proceed to Checkout" link (don't worry, it's free).
+4. On the command line, execute `docker login` and provide your credentials.
+5. Build the Docker image using the command `docker build -t sendgrid/sendgrid-java -f Dockerfile .`
+6. Run `docker run -it sendgrid/sendgrid-java`.
+
+<a name="Info"></a>
+# Info
+
+This Docker image contains
+ - `sendgrid-java`
+ - Stoplight's Prism, which lets you try out the API without actually sending email
+
+Run it in interactive mode with `-it`.
+
+You can mount repositories in the `/mnt/sendgrid-java` and `/mnt/java-http-client` directories to use them instead of the default SendGrid libraries. Read on for more info.
+
+<a name="Testing"></a>
+# Testing
+Testing is easy!  Run the container, `cd sendgrid`, and run `./gradlew test`.
+
+<a name="about"></a>
+# About
+
+sendgrid-java is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+
+sendgrid-java is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-java are trademarks of SendGrid, Inc.
+
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+clear
+
+# check for + link mounted libraries:
+if [ -d /mnt/sendgrid-java ]
+then
+	rm /root/sendgrid
+	ln -s /mnt/sendgrid-java/sendgrid
+	echo "Linked mounted sendgrid-java's code to /root/sendgrid"
+fi
+
+SENDGRID_JAVA_VERSION="1.0.0"
+echo "Welcome to sendgrid-java docker v${SENDGRID_JAVA_VERSION}."
+echo
+
+if [ "$1" != "--no-mock" ]
+then
+	echo "Starting Prism in mock mode. Calls made to Prism will not actually send emails."
+	echo "Disable this by running this container with --no-mock."
+	prism run --mock --spec $OAI_SPEC_URL 2> /dev/null &
+else
+	echo "Starting Prism in live (--no-mock) mode. Calls made to Prism will send emails."
+	prism run --spec $OAI_SPEC_URL 2> /dev/null  &
+fi
+echo "To use Prism, make API calls to localhost:4010. For example,"
+echo "    sg = sendgrid.SendGridAPIClient("
+echo "        host='http://localhost:4010/',"
+echo "        api_key=os.environ.get('SENDGRID_API_KEY_CAMPAIGNS'))"
+echo "To stop Prism, run \"kill $!\" from the shell."
+
+bash


### PR DESCRIPTION
Added support for Java 8. Note that due to Oracle's licensing, this only supports Java 8.

This fixes issue https://github.com/sendgrid/sendgrid-java/issues/230