### PR TITLE
Fixed prism issue and changed jdk to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,8 @@
 language: java
 matrix:
   include:
-    - os: linux
-      dist: precise
-      jdk: openjdk7
-    - os: linux
-      dist: precise
-      jdk: oraclejdk7
-    - os: linux
-      jdk: oraclejdk8
+    - jdk: openjdk8
+    - jdk: oraclejdk8
 before_script:
 - "./scripts/startPrism.sh &"
 - sleep 20

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-sudo: false
 matrix:
   include:
     - os: linux


### PR DESCRIPTION
<!-- 


Fill out this form in the body:
-->
Closes: #367 #363 

**Description of the change**:

I fixed the prism issue, it needed sudo to work. Also updated jdk to 8(openjdk8 and oraclejdk8)
Fixes #367 and #363 .

removed sudo:false, so that sudo will be enabled(that is the default). Without sudo, prism was giving permission denied error. Also, changed matrix to use jdk8(both openjdk and oraclejdk). You could just remove matrix, but in my experience, it's easier to ensure that only those builds are created that we want, when we use matrix. Otherwise, sometimes two different options can create unnecessary/unexpected builds. So I kept matrix.