### PR TITLE
Updated build.gradle to always pull latest minor release.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
 }
 
 dependencies {
-  compile 'com.sendgrid:java-http-client:4.1.0'
+  compile 'com.sendgrid:java-http-client:4.+'
   compile 'com.fasterxml.jackson.core:jackson-core:2.5.3'
   compile 'com.fasterxml.jackson.core:jackson-annotations:2.5.3'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.5.3'


### PR DESCRIPTION
Updated build.gradle to always depend on latest minor version. Since java-http-client falls under sendgrid sphere, this should not be a major hazard.