### PR TITLE
Use Azul's Zulu JDK, which does not have restrictive licensing.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM store/oracle/serverjre:8
+FROM azul/zulu-openjdk:8
 
 ENV OAI_SPEC_URL="https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"
 
-RUN yum install -y git 
+RUN apt-get update && apt-get install -y git curl
 
 WORKDIR /root
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
  - `v1.0.0`, `latest` [(Dockerfile)](https://github.com/sendgrid/sendgrid-java/blob/master/docker/Dockerfile)
 
 # Quick reference
-Due to Oracle's JDK license, you must build this Docker image using the official Oracle image located in the Docker Store. You will need a Docker store account. Once you have an account, you must accept the Oracle license [here](https://store.docker.com/images/oracle-serverjre-8). On the command line, type `docker login` and provide your credentials. You may then build the image using this command `docker build -t sendgrid/sendgrid-java -f Dockerfile .`
+Build the image using this command `docker build -t sendgrid/sendgrid-java -f Dockerfile .`
 
  - **Where to get help:**
    [Contact SendGrid Support](https://support.sendgrid.com/hc/en-us)

--- a/docker/USAGE.md
+++ b/docker/USAGE.md
@@ -4,11 +4,8 @@ You can use Docker to easily try out or test sendgrid-java.
 # Quickstart
 
 1. Install Docker on your machine.
-2. If you have not done so, create a Docker Store account [here](https://store.docker.com/signup?next=%2F)
-3. Navigate [here](https://store.docker.com/images/oracle-serverjre-8) and click the "Proceed to Checkout" link (don't worry, it's free).
-4. On the command line, execute `docker login` and provide your credentials.
-5. Build the Docker image using the command `docker build -t sendgrid/sendgrid-java -f Dockerfile .`
-6. Run `docker run -it sendgrid/sendgrid-java`.
+2. Build the Docker image using the command `docker build -t sendgrid/sendgrid-java -f Dockerfile .`
+3. Run `docker run -it sendgrid/sendgrid-java`.
 
 <a name="Info"></a>
 # Info


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
    - N/A -- no new tests needed (but the existing ones do pass)
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified
    - N/A -- seems like overkill. It was a simple dockerfile before, now it's a different simple dockerfile

### Short description of what this PR does:
Uses the Zulu JDK so that users no longer need to deal with licensing hassles to build the docker image needed for running the tests. This is a build of OpenJDK by Azul, who is a commercial JVM vendor. Zulu builds are certified to pass the Java TCK (the same test suite used to certify Oracle JVMs, as well as others).