### PR TITLE
Fix #404 Add ability to Impersonate Subusers

### DIFF
--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -41,6 +41,9 @@ public class SendGrid implements SendGridAPI {
   /** The number of milliseconds to sleep between retries. */
   private int rateLimitSleep;
 
+  /** The subuser to be impersonated. */
+  private String subuser;
+
   /**
    * Construct a new SendGrid API wrapper.
    * @param apiKey is your SendGrid API Key: https://app.sendgrid.com/settings/api_keys
@@ -191,6 +194,31 @@ public class SendGrid implements SendGridAPI {
    */
   public void setRateLimitSleep(int rateLimitSleep) {
     this.rateLimitSleep = rateLimitSleep;
+  }
+
+  /**
+   * Add the subuser to be impersonated to the subsequent requests
+   * @param subuser the subuser to be impersonated
+   */
+  public void addImpersonateSubuser(String subuser) {
+    this.subuser = subuser;
+    this.addRequestHeader("on-behalf-of", subuser);
+  }
+
+  /**
+   * Remove the impersonated subuser from the subsequent requests
+   */
+  public void removeImpersonateSubuser() {
+    this.subuser = null;
+    this.removeRequestHeader("on-behalf-of");
+  }
+
+  /**
+   * Get the impersonated subuser or null if empty
+   * @return the impersonated subuser
+   */
+  public String getImpersonateSubuser() {
+    return this.subuser; 
   }
 
   /**

--- a/src/test/java/com/sendgrid/SendGridTest.java
+++ b/src/test/java/com/sendgrid/SendGridTest.java
@@ -3406,4 +3406,40 @@ public class SendGridTest {
     Assert.assertEquals(200, response.getStatusCode());
   }
 
+  @Test
+  public void test_add_impersonate_subuser() {
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY);
+    Map<String,String> requestHeaders = new HashMap<>();
+
+    sg.addImpersonateSubuser("subusername");
+    requestHeaders.put("on-behalf-of", "subusername");
+    Assert.assertEquals(sg.getRequestHeaders().get("on-behalf-of"), requestHeaders.get("on-behalf-of"));
+  }
+
+  @Test
+  public void test_remove_impersonate_subuser() {
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY);
+    Map<String,String> requestHeaders = new HashMap<>();
+
+    sg.addImpersonateSubuser("subusername");
+    requestHeaders.put("on-behalf-of", "subusername");
+    Assert.assertEquals(sg.getRequestHeaders().get("on-behalf-of"), requestHeaders.get("on-behalf-of"));
+
+    sg.removeImpersonateSubuser();
+    requestHeaders.remove("on-behalf-of");
+    Assert.assertEquals(sg.getRequestHeaders().get("on-behalf-of"), requestHeaders.get("on-behalf-of"));
+  }
+
+  @Test
+  public void test_get_impersonate_subuser() {
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY);
+    
+    sg.addImpersonateSubuser("subusername");
+    Assert.assertEquals(sg.getImpersonateSubuser(), "subusername");
+
+    sg.removeImpersonateSubuser();
+    Assert.assertEquals(sg.getImpersonateSubuser(), null);
+
+  }
+
 }


### PR DESCRIPTION
Sendgrid API has a feature that allows a parent account to impersonate
subusers by including an HTTP header "on-behalf-of" in the API request.
This commit enables users to use impersonation.

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- This PR adds functionality to impersonate subusers

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.