### PR TITLE
Fix link to LICENSE.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,4 +237,4 @@ Please email the Developer Experience Team [here](mailto:dx@sendgrid.com) in cas
 sendgrid-java is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-java are trademarks of SendGrid, Inc.
 
 # License
-[The MIT License (MIT)](LICENSE.txt)
+[The MIT License (MIT)](LICENSE.md)


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:

The link to the `LICENSE` file in `README.md` points to `LICENSE.txt` when the actual MIT license file is `LICENSE.md`.

This PR fixes it to be the proper link. :+1: 