### PR TITLE
Type Exception Handling for mail/send API call (fix for #510)

### DIFF
--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -1,5 +1,8 @@
 package com.sendgrid;
 
+import com.sendgrid.typechecker.TypeCheckException;
+import com.sendgrid.typechecker.TypeChecker;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +43,8 @@ public class SendGrid implements SendGridAPI {
 
   /** The number of milliseconds to sleep between retries. */
   private int rateLimitSleep;
+
+  private TypeChecker typeChecker = new TypeChecker();
 
   /**
    * Construct a new SendGrid API wrapper.
@@ -209,7 +214,9 @@ public class SendGrid implements SendGridAPI {
    * @return the response object.
    * @throws IOException in case of a network error.
    */
-  public Response api(Request request) throws IOException {
+  public Response api(Request request) throws IOException, TypeCheckException {
+    typeChecker.checkRequest(request);
+
     Request req = new Request();
     req.setMethod(request.getMethod());
     req.setBaseUri(this.host);
@@ -260,7 +267,7 @@ public class SendGrid implements SendGridAPI {
         for (int i = 0; i < rateLimitRetry; ++i) {
           try {
             response = api(request);
-          } catch (IOException ex) {
+          } catch (IOException | TypeCheckException ex) {
             // Stop retrying if there is a network error.
             callback.error(ex);
             return;

--- a/src/main/java/com/sendgrid/SendGrid.java
+++ b/src/main/java/com/sendgrid/SendGrid.java
@@ -6,8 +6,8 @@ import com.sendgrid.typechecker.TypeChecker;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
   * Class SendGrid allows for quick and easy access to the SendGrid API.

--- a/src/main/java/com/sendgrid/SendGridAPI.java
+++ b/src/main/java/com/sendgrid/SendGridAPI.java
@@ -87,5 +87,5 @@ public interface SendGridAPI {
    * @return returns a response.
    * @throws IOException in case of network or marshal error.
    */
-  public Response api(Request request) throws IOException;
+  public Response api(Request request) throws Exception;
 }

--- a/src/main/java/com/sendgrid/typechecker/MailFieldIds.java
+++ b/src/main/java/com/sendgrid/typechecker/MailFieldIds.java
@@ -1,0 +1,80 @@
+package com.sendgrid.typechecker;
+
+public class MailFieldIds {
+
+    public static final String PERSONALIZATIONS = "personalizations";
+
+    public static final String TO = "to";
+    public static final String CC = "cc";
+    public static final String BCC = "bcc";
+
+    public static final String FROM = "from";
+    public static final String REPLY_TO = "reply_to";
+    public static final String EMAIL = "email";
+    public static final String NAME = "name";
+
+    public static final String SUBJECT = "subject";
+    public static final String HEADERS = "headers";
+    public static final String SUBSTITUTIONS = "substitutions";
+
+    public static final String CUSTOM_ARGS = "custom_args";
+    public static final String SEND_AT = "send_at";
+
+
+    public static final String CONTENT = "content";
+    public static final String TYPE = "type";
+    public static final String VALUE = "value";
+
+    public static final String ATTACHMENTS = "attachments";
+
+    public static final String FILENAME = "filename";
+    public static final String DISPOSITION = "disposition";
+    public static final String CONTENT_ID = "content_id";
+
+    public static final String TEMPLATE_ID = "template_id";
+
+    public static final String SECTIONS = "sections";
+
+    public static final String CATEGORIES = "categories";
+
+    public static final String BATCH_ID = "batch_id";
+    public static final String ASM = "asm";
+
+    public static final String GROUP_ID = "group_id";
+    public static final String GROUPS_TO_DISPLAY = "groups_to_display";
+
+    public static final String IP_POOL_NAME = "ip_pool_name";
+
+
+    public static final String MAIL_SETTINGS = "mail_settings";
+    public static final String ENABLE = "enable";
+
+    public static final String BYPASS_LIST_MANAGEMENT = "bypass_list_management";
+    public static final String FOOTER = "footer";
+    public static final String TEXT = "text";
+    public static final String HTML = "html";
+
+    public static final String SANDBOX_MODE = "sandbox_mode";
+    public static final String SPAM_CHECK ="spam_check";
+    public static final String THRESHOLD = "threshold";
+    public static final String POST_TO_URL = "post_to_url";
+
+    public static final String TRACKING_SETTINGS = "tracking_settings";
+    public static final String CLICK_TRACKING = "click_tracking";
+
+    public static final String ENABLE_TEXT = "enable_text";
+    public static final String OPEN_TRACKING = "open_tracking";
+    public static final String SUBSTITUTION_TAG = "substitution_tag";
+
+    public static final String SUBSCRIPTION_TRACKING = "subscription_tracking";
+    public static final String GANALYTICS = "ganalytics";
+    public static final String UTM_SOURCE = "utm_source";
+    public static final String UTM_MEDIUM = "utm_medium";
+
+    public static final String UTM_TERM = "utm_term";
+    public static final String UTM_CONTENT = "utm_content";
+    public static final String UTM_CAMPAIGN = "utm_campaign";
+
+
+    private MailFieldIds() {}
+}

--- a/src/main/java/com/sendgrid/typechecker/MailFieldIds.java
+++ b/src/main/java/com/sendgrid/typechecker/MailFieldIds.java
@@ -2,79 +2,80 @@ package com.sendgrid.typechecker;
 
 public class MailFieldIds {
 
-    public static final String PERSONALIZATIONS = "personalizations";
+  public static final String PERSONALIZATIONS = "personalizations";
 
-    public static final String TO = "to";
-    public static final String CC = "cc";
-    public static final String BCC = "bcc";
+  public static final String TO = "to";
+  public static final String CC = "cc";
+  public static final String BCC = "bcc";
 
-    public static final String FROM = "from";
-    public static final String REPLY_TO = "reply_to";
-    public static final String EMAIL = "email";
-    public static final String NAME = "name";
+  public static final String FROM = "from";
+  public static final String REPLY_TO = "reply_to";
+  public static final String EMAIL = "email";
+  public static final String NAME = "name";
 
-    public static final String SUBJECT = "subject";
-    public static final String HEADERS = "headers";
-    public static final String SUBSTITUTIONS = "substitutions";
+  public static final String SUBJECT = "subject";
+  public static final String HEADERS = "headers";
+  public static final String SUBSTITUTIONS = "substitutions";
 
-    public static final String CUSTOM_ARGS = "custom_args";
-    public static final String SEND_AT = "send_at";
-
-
-    public static final String CONTENT = "content";
-    public static final String TYPE = "type";
-    public static final String VALUE = "value";
-
-    public static final String ATTACHMENTS = "attachments";
-
-    public static final String FILENAME = "filename";
-    public static final String DISPOSITION = "disposition";
-    public static final String CONTENT_ID = "content_id";
-
-    public static final String TEMPLATE_ID = "template_id";
-
-    public static final String SECTIONS = "sections";
-
-    public static final String CATEGORIES = "categories";
-
-    public static final String BATCH_ID = "batch_id";
-    public static final String ASM = "asm";
-
-    public static final String GROUP_ID = "group_id";
-    public static final String GROUPS_TO_DISPLAY = "groups_to_display";
-
-    public static final String IP_POOL_NAME = "ip_pool_name";
+  public static final String CUSTOM_ARGS = "custom_args";
+  public static final String SEND_AT = "send_at";
 
 
-    public static final String MAIL_SETTINGS = "mail_settings";
-    public static final String ENABLE = "enable";
+  public static final String CONTENT = "content";
+  public static final String TYPE = "type";
+  public static final String VALUE = "value";
 
-    public static final String BYPASS_LIST_MANAGEMENT = "bypass_list_management";
-    public static final String FOOTER = "footer";
-    public static final String TEXT = "text";
-    public static final String HTML = "html";
+  public static final String ATTACHMENTS = "attachments";
 
-    public static final String SANDBOX_MODE = "sandbox_mode";
-    public static final String SPAM_CHECK ="spam_check";
-    public static final String THRESHOLD = "threshold";
-    public static final String POST_TO_URL = "post_to_url";
+  public static final String FILENAME = "filename";
+  public static final String DISPOSITION = "disposition";
+  public static final String CONTENT_ID = "content_id";
 
-    public static final String TRACKING_SETTINGS = "tracking_settings";
-    public static final String CLICK_TRACKING = "click_tracking";
+  public static final String TEMPLATE_ID = "template_id";
 
-    public static final String ENABLE_TEXT = "enable_text";
-    public static final String OPEN_TRACKING = "open_tracking";
-    public static final String SUBSTITUTION_TAG = "substitution_tag";
+  public static final String SECTIONS = "sections";
 
-    public static final String SUBSCRIPTION_TRACKING = "subscription_tracking";
-    public static final String GANALYTICS = "ganalytics";
-    public static final String UTM_SOURCE = "utm_source";
-    public static final String UTM_MEDIUM = "utm_medium";
+  public static final String CATEGORIES = "categories";
 
-    public static final String UTM_TERM = "utm_term";
-    public static final String UTM_CONTENT = "utm_content";
-    public static final String UTM_CAMPAIGN = "utm_campaign";
+  public static final String BATCH_ID = "batch_id";
+  public static final String ASM = "asm";
+
+  public static final String GROUP_ID = "group_id";
+  public static final String GROUPS_TO_DISPLAY = "groups_to_display";
+
+  public static final String IP_POOL_NAME = "ip_pool_name";
 
 
-    private MailFieldIds() {}
+  public static final String MAIL_SETTINGS = "mail_settings";
+  public static final String ENABLE = "enable";
+
+  public static final String BYPASS_LIST_MANAGEMENT = "bypass_list_management";
+  public static final String FOOTER = "footer";
+  public static final String TEXT = "text";
+  public static final String HTML = "html";
+
+  public static final String SANDBOX_MODE = "sandbox_mode";
+  public static final String SPAM_CHECK = "spam_check";
+  public static final String THRESHOLD = "threshold";
+  public static final String POST_TO_URL = "post_to_url";
+
+  public static final String TRACKING_SETTINGS = "tracking_settings";
+  public static final String CLICK_TRACKING = "click_tracking";
+
+  public static final String ENABLE_TEXT = "enable_text";
+  public static final String OPEN_TRACKING = "open_tracking";
+  public static final String SUBSTITUTION_TAG = "substitution_tag";
+
+  public static final String SUBSCRIPTION_TRACKING = "subscription_tracking";
+  public static final String GANALYTICS = "ganalytics";
+  public static final String UTM_SOURCE = "utm_source";
+  public static final String UTM_MEDIUM = "utm_medium";
+
+  public static final String UTM_TERM = "utm_term";
+  public static final String UTM_CONTENT = "utm_content";
+  public static final String UTM_CAMPAIGN = "utm_campaign";
+
+
+  private MailFieldIds() {
+  }
 }

--- a/src/main/java/com/sendgrid/typechecker/RequiredFieldMissingException.java
+++ b/src/main/java/com/sendgrid/typechecker/RequiredFieldMissingException.java
@@ -1,9 +1,7 @@
 package com.sendgrid.typechecker;
 
-import com.sun.istack.internal.NotNull;
-
 class RequiredFieldMissingException extends TypeCheckException {
-  RequiredFieldMissingException(@NotNull String msg) {
+  RequiredFieldMissingException(String msg) {
     super(msg);
   }
 }

--- a/src/main/java/com/sendgrid/typechecker/RequiredFieldMissingException.java
+++ b/src/main/java/com/sendgrid/typechecker/RequiredFieldMissingException.java
@@ -1,0 +1,9 @@
+package com.sendgrid.typechecker;
+
+import com.sun.istack.internal.NotNull;
+
+class RequiredFieldMissingException extends TypeCheckException {
+  RequiredFieldMissingException(@NotNull String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/sendgrid/typechecker/TypeAsserts.java
+++ b/src/main/java/com/sendgrid/typechecker/TypeAsserts.java
@@ -2,23 +2,39 @@ package com.sendgrid.typechecker;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.sun.istack.internal.NotNull;
-import com.sun.istack.internal.Nullable;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class TypeAsserts {
 
-  public static void assertNotNull(@NotNull String fieldId, @Nullable Object value) throws RequiredFieldMissingException {
+  /**
+   * Call this method to check object not null.
+   * @param fieldId id to be shown in exception log
+   * @param value object to be checked
+   * @throws RequiredFieldMissingException thrown if object is null
+   */
+  public static void assertNotNull(String fieldId,  Object value)
+      throws RequiredFieldMissingException {
     if (value == null) {
       throw new RequiredFieldMissingException("Field: " + fieldId + " must not be null");
     }
   }
 
-  public static void assertString(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check JsonNode is of type JsonNode.STRING.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if JsonNode is not of type JsonNode.STRING
+   */
+  public static void assertString(String fieldId,
+                                  boolean isRequired,
+                                   JsonNode value) throws TypeCheckException {
     if (isRequired) {
       assertNotNull(fieldId, value);
     }
@@ -27,7 +43,16 @@ public class TypeAsserts {
     }
   }
 
-  public static void assertInteger(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check JsonNode is of type JsonNode.NUMBER.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if JsonNode is not of type JsonNode.NUMBER
+   */
+  public static void assertInteger(String fieldId,
+                                   boolean isRequired,
+                                    JsonNode value) throws TypeCheckException {
     if (isRequired) {
       assertNotNull(fieldId, value);
     }
@@ -37,7 +62,16 @@ public class TypeAsserts {
     }
   }
 
-  public static void assertBoolean(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check JsonNode is of type JsonNode.BOOLEAN.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if JsonNode is not of type JsonNode.BOOLEAN
+   */
+  public static void assertBoolean(String fieldId,
+                                   boolean isRequired,
+                                    JsonNode value) throws TypeCheckException {
     if (isRequired) {
       assertNotNull(fieldId, value);
     }
@@ -46,7 +80,16 @@ public class TypeAsserts {
     }
   }
 
-  public static void assertObject(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check JsonNode is of type JsonNode.OBJECT.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if JsonNode is not of type JsonNode.OBJECT
+   */
+  public static void assertObject(String fieldId,
+                                  boolean isRequired,
+                                   JsonNode value) throws TypeCheckException {
     if (isRequired) {
       assertNotNull(fieldId, value);
     }
@@ -55,7 +98,16 @@ public class TypeAsserts {
     }
   }
 
-  public static void assertObjectArray(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check JsonNode is of type JsonNode.ARRAY.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if JsonNode is not of type JsonNode.ARRAY
+   */
+  public static void assertObjectArray(String fieldId,
+                                       boolean isRequired,
+                                        JsonNode value) throws TypeCheckException {
     if (isRequired) {
       assertNotNull(fieldId, value);
     }
@@ -64,25 +116,53 @@ public class TypeAsserts {
     }
   }
 
-  public static void assertIntArray(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check json array items are of type JsonNode.NUMBER.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if json array items are not of type JsonNode.NUMBER
+   */
+  public static void assertIntArray(String fieldId,
+                                    boolean isRequired,
+                                     JsonNode value) throws TypeCheckException {
     assertObjectArray(fieldId, isRequired, value);
 
     List<JsonNode> notIntNodes = StreamSupport.stream(value.spliterator(), false)
-        .filter((el) -> el.getNodeType() != JsonNodeType.NUMBER)
-        .collect(Collectors.toList());
+        .filter(new Predicate<JsonNode>() {
+          @Override
+          public boolean test(JsonNode el) {
+            return el.getNodeType() != JsonNodeType.NUMBER;
+          }
+        })
+        .collect(Collectors.<JsonNode>toList());
 
     if (!notIntNodes.isEmpty()) {
       throw new TypeCheckException("Field: " + fieldId + " contents must be of type Integer");
     }
   }
 
-  public static void assertStringArray(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+  /**
+   * Call this method to check json array items are of type JsonNode.STRING.
+   * @param fieldId id to be shown in exception log
+   * @param isRequired if true object is checked for null
+   * @param value node to be checked
+   * @throws TypeCheckException thrown if json array items are not of type JsonNode.STRING
+   */
+  public static void assertStringArray(String fieldId,
+                                       boolean isRequired,
+                                        JsonNode value) throws TypeCheckException {
     assertObjectArray(fieldId, isRequired, value);
 
     if (value != null) {
       List<JsonNode> notIntNodes = StreamSupport.stream(value.spliterator(), false)
-          .filter((el) -> el.getNodeType() != JsonNodeType.STRING)
-          .collect(Collectors.toList());
+          .filter(new Predicate<JsonNode>() {
+            @Override
+            public boolean test(JsonNode el) {
+              return el.getNodeType() != JsonNodeType.STRING;
+            }
+          })
+          .collect(Collectors.<JsonNode>toList());
 
       if (!notIntNodes.isEmpty()) {
         throw new TypeCheckException("Field: " + fieldId + " contents must be of type String");
@@ -90,18 +170,36 @@ public class TypeAsserts {
     }
   }
 
-  public static void applyAssertions(@NotNull ThrowingConsumer<JsonNode, TypeCheckException> assertions, @NotNull JsonNode value) throws TypeCheckException {
-    List<TypeCheckException> nodesCheckResult = StreamSupport.stream(value.spliterator(), true)
-        .map((el) -> {
-          try {
-            assertions.accept(el);
-            return null;
-          } catch (TypeCheckException ex) {
-            return ex;
-          }
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+  /**
+   * Call this method to apply assertions on all json array items.
+   * @param assertions assertions to be applied on node children
+   * @param value node array container
+   * @throws TypeCheckException thrown if any of json array items are not satisfying assertions
+   */
+  public static void applyAssertions(
+       ThrowingConsumer<JsonNode, TypeCheckException> assertions,
+       JsonNode value) throws TypeCheckException {
+    final ThrowingConsumer<JsonNode, TypeCheckException> asserts = assertions;
+    List<TypeCheckException> nodesCheckResult =
+        StreamSupport.stream(value.spliterator(), true)
+            .map(new Function<JsonNode, TypeCheckException>() {
+              @Override
+              public TypeCheckException apply(JsonNode el) {
+                try {
+                  asserts.accept(el);
+                  return null;
+                } catch (TypeCheckException ex) {
+                  return ex;
+                }
+              }
+            })
+            .filter(new Predicate<TypeCheckException>() {
+              @Override
+              public boolean test(TypeCheckException obj) {
+                return Objects.nonNull(obj);
+              }
+            })
+            .collect(Collectors.<TypeCheckException>toList());
 
     if (nodesCheckResult != null && !nodesCheckResult.isEmpty()) {
       throw nodesCheckResult.get(0);

--- a/src/main/java/com/sendgrid/typechecker/TypeAsserts.java
+++ b/src/main/java/com/sendgrid/typechecker/TypeAsserts.java
@@ -1,0 +1,118 @@
+package com.sendgrid.typechecker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.sun.istack.internal.NotNull;
+import com.sun.istack.internal.Nullable;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class TypeAsserts {
+
+  public static void assertNotNull(@NotNull String fieldId, @Nullable Object value) throws RequiredFieldMissingException {
+    if (value == null) {
+      throw new RequiredFieldMissingException("Field: " + fieldId + " must not be null");
+    }
+  }
+
+  public static void assertString(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    if (isRequired) {
+      assertNotNull(fieldId, value);
+    }
+    if (value != null && value.getNodeType() != JsonNodeType.STRING) {
+      throw new TypeCheckException("Field: " + fieldId + " must be of type String");
+    }
+  }
+
+  public static void assertInteger(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    if (isRequired) {
+      assertNotNull(fieldId, value);
+    }
+
+    if (value != null && value.getNodeType() != JsonNodeType.NUMBER) {
+      throw new TypeCheckException("Field: " + fieldId + " must be of type Integer");
+    }
+  }
+
+  public static void assertBoolean(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    if (isRequired) {
+      assertNotNull(fieldId, value);
+    }
+    if (value != null && value.getNodeType() != JsonNodeType.BOOLEAN) {
+      throw new TypeCheckException("Field: " + fieldId + " must be of type Boolean");
+    }
+  }
+
+  public static void assertObject(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    if (isRequired) {
+      assertNotNull(fieldId, value);
+    }
+    if (value != null && value.getNodeType() != JsonNodeType.OBJECT) {
+      throw new TypeCheckException("Field: " + fieldId + " must be Object");
+    }
+  }
+
+  public static void assertObjectArray(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    if (isRequired) {
+      assertNotNull(fieldId, value);
+    }
+    if (value != null && value.getNodeType() != JsonNodeType.ARRAY) {
+      throw new TypeCheckException("Field: " + fieldId + " must be of type Array");
+    }
+  }
+
+  public static void assertIntArray(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    assertObjectArray(fieldId, isRequired, value);
+
+    List<JsonNode> notIntNodes = StreamSupport.stream(value.spliterator(), false)
+        .filter((el) -> el.getNodeType() != JsonNodeType.NUMBER)
+        .collect(Collectors.toList());
+
+    if (!notIntNodes.isEmpty()) {
+      throw new TypeCheckException("Field: " + fieldId + " contents must be of type Integer");
+    }
+  }
+
+  public static void assertStringArray(@NotNull String fieldId, boolean isRequired, @Nullable JsonNode value) throws TypeCheckException {
+    assertObjectArray(fieldId, isRequired, value);
+
+    if (value != null) {
+      List<JsonNode> notIntNodes = StreamSupport.stream(value.spliterator(), false)
+          .filter((el) -> el.getNodeType() != JsonNodeType.STRING)
+          .collect(Collectors.toList());
+
+      if (!notIntNodes.isEmpty()) {
+        throw new TypeCheckException("Field: " + fieldId + " contents must be of type String");
+      }
+    }
+  }
+
+  public static void applyAssertions(@NotNull ThrowingConsumer<JsonNode, TypeCheckException> assertions, @NotNull JsonNode value) throws TypeCheckException {
+    List<TypeCheckException> nodesCheckResult = StreamSupport.stream(value.spliterator(), true)
+        .map((el) -> {
+          try {
+            assertions.accept(el);
+            return null;
+          } catch (TypeCheckException ex) {
+            return ex;
+          }
+        })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+
+    if (nodesCheckResult != null && !nodesCheckResult.isEmpty()) {
+      throw nodesCheckResult.get(0);
+    }
+  }
+
+  @FunctionalInterface
+  public interface ThrowingConsumer<T, E extends Exception> {
+    void accept(T t) throws E;
+  }
+
+  private TypeAsserts() {
+  }
+}

--- a/src/main/java/com/sendgrid/typechecker/TypeCheckException.java
+++ b/src/main/java/com/sendgrid/typechecker/TypeCheckException.java
@@ -1,9 +1,7 @@
 package com.sendgrid.typechecker;
 
-import com.sun.istack.internal.NotNull;
-
 public class TypeCheckException extends Exception {
-    public TypeCheckException(@NotNull String message) {
-        super(message);
-    }
+  public TypeCheckException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/sendgrid/typechecker/TypeCheckException.java
+++ b/src/main/java/com/sendgrid/typechecker/TypeCheckException.java
@@ -1,0 +1,9 @@
+package com.sendgrid.typechecker;
+
+import com.sun.istack.internal.NotNull;
+
+public class TypeCheckException extends Exception {
+    public TypeCheckException(@NotNull String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sendgrid/typechecker/TypeChecker.java
+++ b/src/main/java/com/sendgrid/typechecker/TypeChecker.java
@@ -1,19 +1,79 @@
 package com.sendgrid.typechecker;
 
+import static com.sendgrid.typechecker.MailFieldIds.ASM;
+import static com.sendgrid.typechecker.MailFieldIds.ATTACHMENTS;
+import static com.sendgrid.typechecker.MailFieldIds.BATCH_ID;
+import static com.sendgrid.typechecker.MailFieldIds.BCC;
+import static com.sendgrid.typechecker.MailFieldIds.BYPASS_LIST_MANAGEMENT;
+import static com.sendgrid.typechecker.MailFieldIds.CATEGORIES;
+import static com.sendgrid.typechecker.MailFieldIds.CC;
+import static com.sendgrid.typechecker.MailFieldIds.CLICK_TRACKING;
+import static com.sendgrid.typechecker.MailFieldIds.CONTENT;
+import static com.sendgrid.typechecker.MailFieldIds.CONTENT_ID;
+import static com.sendgrid.typechecker.MailFieldIds.CUSTOM_ARGS;
+import static com.sendgrid.typechecker.MailFieldIds.DISPOSITION;
+import static com.sendgrid.typechecker.MailFieldIds.EMAIL;
+import static com.sendgrid.typechecker.MailFieldIds.ENABLE;
+import static com.sendgrid.typechecker.MailFieldIds.ENABLE_TEXT;
+import static com.sendgrid.typechecker.MailFieldIds.FILENAME;
+import static com.sendgrid.typechecker.MailFieldIds.FOOTER;
+import static com.sendgrid.typechecker.MailFieldIds.FROM;
+import static com.sendgrid.typechecker.MailFieldIds.GANALYTICS;
+import static com.sendgrid.typechecker.MailFieldIds.GROUPS_TO_DISPLAY;
+import static com.sendgrid.typechecker.MailFieldIds.GROUP_ID;
+import static com.sendgrid.typechecker.MailFieldIds.HEADERS;
+import static com.sendgrid.typechecker.MailFieldIds.HTML;
+import static com.sendgrid.typechecker.MailFieldIds.IP_POOL_NAME;
+import static com.sendgrid.typechecker.MailFieldIds.MAIL_SETTINGS;
+import static com.sendgrid.typechecker.MailFieldIds.NAME;
+import static com.sendgrid.typechecker.MailFieldIds.OPEN_TRACKING;
+import static com.sendgrid.typechecker.MailFieldIds.PERSONALIZATIONS;
+import static com.sendgrid.typechecker.MailFieldIds.POST_TO_URL;
+import static com.sendgrid.typechecker.MailFieldIds.REPLY_TO;
+import static com.sendgrid.typechecker.MailFieldIds.SANDBOX_MODE;
+import static com.sendgrid.typechecker.MailFieldIds.SECTIONS;
+import static com.sendgrid.typechecker.MailFieldIds.SEND_AT;
+import static com.sendgrid.typechecker.MailFieldIds.SPAM_CHECK;
+import static com.sendgrid.typechecker.MailFieldIds.SUBJECT;
+import static com.sendgrid.typechecker.MailFieldIds.SUBSCRIPTION_TRACKING;
+import static com.sendgrid.typechecker.MailFieldIds.SUBSTITUTIONS;
+import static com.sendgrid.typechecker.MailFieldIds.SUBSTITUTION_TAG;
+import static com.sendgrid.typechecker.MailFieldIds.TEMPLATE_ID;
+import static com.sendgrid.typechecker.MailFieldIds.TEXT;
+import static com.sendgrid.typechecker.MailFieldIds.THRESHOLD;
+import static com.sendgrid.typechecker.MailFieldIds.TO;
+import static com.sendgrid.typechecker.MailFieldIds.TRACKING_SETTINGS;
+import static com.sendgrid.typechecker.MailFieldIds.TYPE;
+import static com.sendgrid.typechecker.MailFieldIds.UTM_CAMPAIGN;
+import static com.sendgrid.typechecker.MailFieldIds.UTM_CONTENT;
+import static com.sendgrid.typechecker.MailFieldIds.UTM_MEDIUM;
+import static com.sendgrid.typechecker.MailFieldIds.UTM_SOURCE;
+import static com.sendgrid.typechecker.MailFieldIds.UTM_TERM;
+import static com.sendgrid.typechecker.MailFieldIds.VALUE;
+import static com.sendgrid.typechecker.TypeAsserts.applyAssertions;
+import static com.sendgrid.typechecker.TypeAsserts.assertBoolean;
+import static com.sendgrid.typechecker.TypeAsserts.assertIntArray;
+import static com.sendgrid.typechecker.TypeAsserts.assertInteger;
+import static com.sendgrid.typechecker.TypeAsserts.assertObject;
+import static com.sendgrid.typechecker.TypeAsserts.assertObjectArray;
+import static com.sendgrid.typechecker.TypeAsserts.assertString;
+import static com.sendgrid.typechecker.TypeAsserts.assertStringArray;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sendgrid.Request;
-import com.sun.istack.internal.NotNull;
-import com.sun.istack.internal.Nullable;
 
 import java.io.IOException;
 
-import static com.sendgrid.typechecker.MailFieldIds.*;
-import static com.sendgrid.typechecker.TypeAsserts.*;
-
 public class TypeChecker {
 
-  public void checkRequest(@NotNull Request request) throws TypeCheckException, IOException {
+  /**
+   * Call this method to check it's body parameters types.
+   * @param request that should be checked
+   * @throws TypeCheckException thrown if type of field is incorrect
+   * @throws IOException thrown if json could not be parsed
+   */
+  public void checkRequest(Request request) throws TypeCheckException, IOException {
     String endpoint = request.getEndpoint();
 
     switch (endpoint) {
@@ -28,56 +88,64 @@ public class TypeChecker {
     }
   }
 
-  public void checkMailParams(@Nullable String body) throws TypeCheckException, IOException {
+  /**
+   * Call this method on json body of mail/send to be sure that all params are of correct type.
+   * @param body of mail/send request in json form
+   * @throws TypeCheckException thrown if type of field is incorrect
+   * @throws IOException thrown if json could not be parsed
+   */
+  public void checkMailParams(String body) throws TypeCheckException, IOException {
     ObjectMapper objectMapper = new ObjectMapper();
-    JsonNode root = objectMapper.readTree(body);
-    if (root == null) throw new TypeCheckException("No body detected");
+    final JsonNode root = objectMapper.readTree(body);
+    if (root == null) {
+      throw new TypeCheckException("No body detected");
+    }
 
     checkPersonalizations(root);
 
-    JsonNode from = root.get(FROM);
+    final JsonNode from = root.get(FROM);
     assertObject(FROM, true, from);
 
     if (from != null) {
       assertNameAndEmail(from, FROM);
     }
 
-    JsonNode to = root.get(REPLY_TO);
+    final JsonNode to = root.get(REPLY_TO);
     assertObject(REPLY_TO, false, to);
 
     if (to != null) {
       assertNameAndEmail(to, REPLY_TO);
     }
 
-    JsonNode subject = root.get(SUBJECT);
+    final JsonNode subject = root.get(SUBJECT);
     assertString(SUBJECT, false, subject);
 
     checkContent(root);
 
     checkAttachments(root);
 
-    JsonNode templateId = root.get(TEMPLATE_ID);
+    final JsonNode templateId = root.get(TEMPLATE_ID);
     assertString(TEMPLATE_ID, false, templateId);
 
-    JsonNode ipPoolName = root.get(IP_POOL_NAME);
+    final JsonNode ipPoolName = root.get(IP_POOL_NAME);
     assertString(IP_POOL_NAME, false, ipPoolName);
 
-    JsonNode categories = root.get(CATEGORIES);
+    final JsonNode categories = root.get(CATEGORIES);
     assertStringArray(CATEGORIES, false, categories);
 
-    JsonNode customArgs = root.get(CUSTOM_ARGS);
+    final JsonNode customArgs = root.get(CUSTOM_ARGS);
     assertObject(CUSTOM_ARGS, false, customArgs);
 
-    JsonNode sections = root.get(SECTIONS);
+    final JsonNode sections = root.get(SECTIONS);
     assertObject(SECTIONS, false, sections);
 
-    JsonNode headers = root.get(HEADERS);
+    final JsonNode headers = root.get(HEADERS);
     assertObject(HEADERS, false, headers);
 
-    JsonNode sendAt = root.get(SEND_AT);
+    final JsonNode sendAt = root.get(SEND_AT);
     assertInteger(SEND_AT, false, sendAt);
 
-    JsonNode batchId = root.get(BATCH_ID);
+    final JsonNode batchId = root.get(BATCH_ID);
     assertString(BATCH_ID, false, batchId);
 
     checkAsm(root);
@@ -89,159 +157,187 @@ public class TypeChecker {
   }
 
   private void checkPersonalizations(JsonNode root) throws TypeCheckException {
-    JsonNode personalizations = root.get(PERSONALIZATIONS);
+    final JsonNode personalizations = root.get(PERSONALIZATIONS);
     assertObjectArray(PERSONALIZATIONS, true, personalizations);
     if (personalizations != null) {
-      applyAssertions((el) -> {
-        JsonNode to = el.get(TO);
-        String personalizationsBase = PERSONALIZATIONS + ".";
+      applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+        @Override
+        public void accept(JsonNode el) throws TypeCheckException {
+          final JsonNode to = el.get(TO);
+          final String personalizationsBase = PERSONALIZATIONS + ".";
 
-        assertObjectArray(personalizationsBase + TO, true, to);
-        if (to != null) {
-          applyAssertions((node) -> assertNameAndEmail(node, personalizationsBase + TO), to);
+          assertObjectArray(personalizationsBase + TO, true, to);
+          if (to != null) {
+            applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+              @Override
+              public void accept(JsonNode jsonNode) throws TypeCheckException {
+                TypeChecker.this.assertNameAndEmail(jsonNode, personalizationsBase + TO);
+              }
+            }, to);
+          }
+
+          final JsonNode cc = el.get(CC);
+          assertObjectArray(personalizationsBase + CC, false, cc);
+          if (cc != null) {
+            applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+              @Override
+              public void accept(JsonNode jsonNode) throws TypeCheckException {
+                TypeChecker.this.assertNameAndEmail(jsonNode, personalizationsBase + CC);
+              }
+            }, cc);
+          }
+
+          final JsonNode bcc = el.get(BCC);
+          assertObjectArray(personalizationsBase + BCC, false, bcc);
+          if (bcc != null) {
+            applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+              @Override
+              public void accept(JsonNode jsonNode) throws TypeCheckException {
+                TypeChecker.this.assertNameAndEmail(jsonNode, personalizationsBase + BCC);
+              }
+            }, bcc);
+          }
+
+          final JsonNode subject = el.get(SUBJECT);
+          assertString(personalizationsBase + SUBJECT, false, subject);
+
+          final JsonNode headers = el.get(HEADERS);
+          assertObject(personalizationsBase + HEADERS, false, headers);
+
+          final JsonNode substitutions = el.get(SUBSTITUTIONS);
+          assertObject(personalizationsBase + SUBSTITUTIONS, false, substitutions);
+
+          final JsonNode customArgs = el.get(CUSTOM_ARGS);
+          assertObject(personalizationsBase + CUSTOM_ARGS, false, customArgs);
+
+          final JsonNode sendAt = el.get(SEND_AT);
+          assertInteger(personalizationsBase + SEND_AT, false, sendAt);
+
         }
-
-        JsonNode cc = el.get(CC);
-        assertObjectArray(personalizationsBase + CC, false, cc);
-        if (cc != null) {
-          applyAssertions((node) -> assertNameAndEmail(node, personalizationsBase + CC), cc);
-        }
-
-        JsonNode bcc = el.get(BCC);
-        assertObjectArray(personalizationsBase + BCC, false, bcc);
-        if (bcc != null) {
-          applyAssertions((node) -> assertNameAndEmail(node, personalizationsBase + BCC), bcc);
-        }
-
-        JsonNode subject = el.get(SUBJECT);
-        assertString(personalizationsBase + SUBJECT, false, subject);
-
-        JsonNode headers = el.get(HEADERS);
-        assertObject(personalizationsBase + HEADERS, false, headers);
-
-        JsonNode substitutions = el.get(SUBSTITUTIONS);
-        assertObject(personalizationsBase + SUBSTITUTIONS, false, substitutions);
-
-        JsonNode customArgs = el.get(CUSTOM_ARGS);
-        assertObject(personalizationsBase + CUSTOM_ARGS, false, customArgs);
-
-        JsonNode sendAt = el.get(SEND_AT);
-        assertInteger(personalizationsBase + SEND_AT, false, sendAt);
-
       }, personalizations);
     }
   }
 
   private void checkContent(JsonNode root) throws TypeCheckException {
-    JsonNode content = root.get(CONTENT);
+    final JsonNode content = root.get(CONTENT);
     assertObjectArray(CONTENT, true, content);
 
     if (content != null) {
-      applyAssertions((el) -> {
-        JsonNode contentType = el.get(TYPE);
-        assertString(CONTENT + "." + TYPE, true, contentType);
+      applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+        @Override
+        public void accept(JsonNode el) throws TypeCheckException {
+          final JsonNode contentType = el.get(TYPE);
+          assertString(CONTENT + "." + TYPE, true, contentType);
 
-        JsonNode contentValue = el.get(VALUE);
-        assertString(CONTENT + "." + VALUE, true, contentValue);
+          final JsonNode contentValue = el.get(VALUE);
+          assertString(CONTENT + "." + VALUE, true, contentValue);
+        }
       }, content);
     }
   }
 
   private void checkAttachments(JsonNode root) throws TypeCheckException {
-    JsonNode attachments = root.get(ATTACHMENTS);
+    final JsonNode attachments = root.get(ATTACHMENTS);
     assertObjectArray(ATTACHMENTS, false, attachments);
 
     if (attachments != null) {
-      applyAssertions((el) -> {
-        JsonNode attachmentsContent = el.get(CONTENT);
-        assertString(ATTACHMENTS + "." + CONTENT, true, attachmentsContent);
+      applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+        @Override
+        public void accept(JsonNode el) throws TypeCheckException {
+          final JsonNode attachmentsContent = el.get(CONTENT);
+          assertString(ATTACHMENTS + "." + CONTENT, true, attachmentsContent);
 
-        JsonNode attachmentsType = el.get(TYPE);
-        assertString(ATTACHMENTS + "." + TYPE, false, attachmentsType);
+          final JsonNode attachmentsType = el.get(TYPE);
+          assertString(ATTACHMENTS + "." + TYPE, false, attachmentsType);
 
-        JsonNode attachmentsFilename = el.get(FILENAME);
-        assertString(ATTACHMENTS + "." + FILENAME, true, attachmentsFilename);
+          final JsonNode attachmentsFilename = el.get(FILENAME);
+          assertString(ATTACHMENTS + "." + FILENAME, true, attachmentsFilename);
 
-        JsonNode attachmentsDisposition = el.get(DISPOSITION);
-        assertString(ATTACHMENTS + "." + DISPOSITION, false, attachmentsDisposition);
+          final JsonNode attachmentsDisposition = el.get(DISPOSITION);
+          assertString(ATTACHMENTS + "." + DISPOSITION, false, attachmentsDisposition);
 
-        JsonNode attachmentsContentId = el.get(CONTENT_ID);
-        assertString(ATTACHMENTS + "." + CONTENT_ID, false, attachmentsContentId);
+          final JsonNode attachmentsContentId = el.get(CONTENT_ID);
+          assertString(ATTACHMENTS + "." + CONTENT_ID, false, attachmentsContentId);
+        }
       }, attachments);
     }
   }
 
   private void checkAsm(JsonNode root) throws TypeCheckException {
-    JsonNode asm = root.get(ASM);
+    final JsonNode asm = root.get(ASM);
     assertObject(ASM, false, asm);
 
     if (asm != null) {
-      JsonNode asmGroupId = asm.get(GROUP_ID);
+      final JsonNode asmGroupId = asm.get(GROUP_ID);
       assertInteger(ASM + "." + GROUP_ID, true, asmGroupId);
 
-      JsonNode asmGroupsToDisplay = asm.get(GROUPS_TO_DISPLAY);
+      final JsonNode asmGroupsToDisplay = asm.get(GROUPS_TO_DISPLAY);
       assertIntArray(ASM + "." + GROUPS_TO_DISPLAY, false, asmGroupsToDisplay);
 
     }
   }
 
   private void checkMailSettings(JsonNode root) throws TypeCheckException {
-    JsonNode mailSettings = root.get(MAIL_SETTINGS);
+    final JsonNode mailSettings = root.get(MAIL_SETTINGS);
     assertObject(MAIL_SETTINGS, false, mailSettings);
 
     if (mailSettings != null) {
-      JsonNode bcc = mailSettings.get(BCC);
+      final JsonNode bcc = mailSettings.get(BCC);
       assertObject(MAIL_SETTINGS + "." + BCC, false, bcc);
 
       if (bcc != null) {
-        JsonNode bccEnable = bcc.get(ENABLE);
+        final JsonNode bccEnable = bcc.get(ENABLE);
         assertBoolean(MAIL_SETTINGS + "." + BCC + "." + ENABLE, false, bccEnable);
 
-        JsonNode bccEmail = bcc.get(EMAIL);
+        final JsonNode bccEmail = bcc.get(EMAIL);
         assertString(MAIL_SETTINGS + "." + BCC + "." + EMAIL, false, bccEmail);
       }
 
-      JsonNode bypassListManagement = mailSettings.get(BYPASS_LIST_MANAGEMENT);
+      final JsonNode bypassListManagement = mailSettings.get(BYPASS_LIST_MANAGEMENT);
       assertObject(MAIL_SETTINGS + "." + BYPASS_LIST_MANAGEMENT, false, bypassListManagement);
 
       if (bypassListManagement != null) {
-        JsonNode bypassEnable = bypassListManagement.get(ENABLE);
-        assertBoolean(MAIL_SETTINGS + "." + BYPASS_LIST_MANAGEMENT + "." + ENABLE, false, bypassEnable);
+        final JsonNode bypassEnable = bypassListManagement.get(ENABLE);
+        assertBoolean(MAIL_SETTINGS + "." + BYPASS_LIST_MANAGEMENT + "." + ENABLE,
+            false,
+            bypassEnable);
       }
 
-      JsonNode footer = mailSettings.get(FOOTER);
+      final JsonNode footer = mailSettings.get(FOOTER);
       assertObject(MAIL_SETTINGS + "." + FOOTER, false, footer);
 
       if (footer != null) {
-        JsonNode footerEnabled = footer.get(ENABLE);
+        final JsonNode footerEnabled = footer.get(ENABLE);
         assertBoolean(MAIL_SETTINGS + "." + FOOTER + "." + ENABLE, false, footerEnabled);
 
-        JsonNode footerText = footer.get(TEXT);
+        final JsonNode footerText = footer.get(TEXT);
         assertString(MAIL_SETTINGS + "." + FOOTER + "." + TEXT, false, footerText);
 
-        JsonNode footerHtml = footer.get(HTML);
+        final JsonNode footerHtml = footer.get(HTML);
         assertString(MAIL_SETTINGS + "." + FOOTER + "." + HTML, false, footerHtml);
       }
 
-      JsonNode sandbox = mailSettings.get(SANDBOX_MODE);
+      final JsonNode sandbox = mailSettings.get(SANDBOX_MODE);
       assertObject(MAIL_SETTINGS + "." + SANDBOX_MODE, false, sandbox);
 
       if (sandbox != null) {
-        JsonNode sandboxEnabled = sandbox.get(ENABLE);
+        final JsonNode sandboxEnabled = sandbox.get(ENABLE);
         assertBoolean(MAIL_SETTINGS + "." + SANDBOX_MODE + "." + ENABLE, false, sandboxEnabled);
       }
 
-      JsonNode spamCheck = mailSettings.get(SPAM_CHECK);
+      final JsonNode spamCheck = mailSettings.get(SPAM_CHECK);
       assertObject(MAIL_SETTINGS + "." + SPAM_CHECK, false, spamCheck);
 
       if (spamCheck != null) {
-        JsonNode spamCheckEnabled = spamCheck.get(ENABLE);
+        final JsonNode spamCheckEnabled = spamCheck.get(ENABLE);
         assertBoolean(MAIL_SETTINGS + "." + SPAM_CHECK + "." + ENABLE, false, spamCheckEnabled);
 
-        JsonNode spamCheckThreshold = spamCheck.get(THRESHOLD);
-        assertInteger(MAIL_SETTINGS + "." + SPAM_CHECK + "." + THRESHOLD, false, spamCheckThreshold);
+        final JsonNode spamCheckThreshold = spamCheck.get(THRESHOLD);
+        assertInteger(MAIL_SETTINGS + "." + SPAM_CHECK + "." + THRESHOLD,
+            false,
+            spamCheckThreshold);
 
-        JsonNode spamCheckUrl = spamCheck.get(POST_TO_URL);
+        final JsonNode spamCheckUrl = spamCheck.get(POST_TO_URL);
         assertString(MAIL_SETTINGS + "." + SPAM_CHECK + "." + POST_TO_URL, false, spamCheckUrl);
       }
 
@@ -249,80 +345,81 @@ public class TypeChecker {
   }
 
   private void checkTrackingSettings(JsonNode root) throws TypeCheckException {
-    JsonNode trackingSettings = root.get(TRACKING_SETTINGS);
+    final JsonNode trackingSettings = root.get(TRACKING_SETTINGS);
     assertObject(TRACKING_SETTINGS, false, trackingSettings);
 
     if (trackingSettings != null) {
-      String clickTrackId = TRACKING_SETTINGS + "." + CLICK_TRACKING;
-      JsonNode clickTracking = trackingSettings.get(CLICK_TRACKING);
+      final String clickTrackId = TRACKING_SETTINGS + "." + CLICK_TRACKING;
+      final JsonNode clickTracking = trackingSettings.get(CLICK_TRACKING);
       assertObject(clickTrackId, false, clickTracking);
 
 
       if (clickTracking != null) {
-        JsonNode clickTrackingEnabled = clickTracking.get(ENABLE);
+        final JsonNode clickTrackingEnabled = clickTracking.get(ENABLE);
         assertBoolean(clickTrackId + "." + ENABLE, false, clickTrackingEnabled);
 
-        JsonNode clickTrackingTextEnabled = clickTracking.get(ENABLE_TEXT);
+        final JsonNode clickTrackingTextEnabled = clickTracking.get(ENABLE_TEXT);
         assertBoolean(clickTrackId + "." + ENABLE_TEXT, false, clickTrackingTextEnabled);
       }
 
-      String openTrackId = TRACKING_SETTINGS + "." + OPEN_TRACKING;
-      JsonNode openTracking = trackingSettings.get(OPEN_TRACKING);
+      final String openTrackId = TRACKING_SETTINGS + "." + OPEN_TRACKING;
+      final JsonNode openTracking = trackingSettings.get(OPEN_TRACKING);
       assertObject(openTrackId, false, openTracking);
 
       if (openTracking != null) {
-        JsonNode openTrackingEnabled = openTracking.get(ENABLE);
+        final JsonNode openTrackingEnabled = openTracking.get(ENABLE);
         assertBoolean(openTrackId + "." + ENABLE, false, openTrackingEnabled);
 
-        JsonNode openTrackingTag = openTracking.get(SUBSTITUTION_TAG);
+        final JsonNode openTrackingTag = openTracking.get(SUBSTITUTION_TAG);
         assertString(openTrackId + "." + SUBSTITUTION_TAG, false, openTrackingTag);
       }
 
-      String subTrackId = TRACKING_SETTINGS + "." + SUBSCRIPTION_TRACKING;
-      JsonNode subscriptionTracking = trackingSettings.get(SUBSCRIPTION_TRACKING);
+      final String subTrackId = TRACKING_SETTINGS + "." + SUBSCRIPTION_TRACKING;
+      final JsonNode subscriptionTracking = trackingSettings.get(SUBSCRIPTION_TRACKING);
       assertObject(subTrackId, false, subscriptionTracking);
 
       if (subscriptionTracking != null) {
-        JsonNode subsTrackEnabled = subscriptionTracking.get(ENABLE);
+        final JsonNode subsTrackEnabled = subscriptionTracking.get(ENABLE);
         assertBoolean(subTrackId + "." + ENABLE, false, subsTrackEnabled);
 
-        JsonNode subsTrackText = subscriptionTracking.get(TEXT);
+        final JsonNode subsTrackText = subscriptionTracking.get(TEXT);
         assertString(subTrackId + "." + TEXT, false, subsTrackText);
 
-        JsonNode subsTrackHtml = subscriptionTracking.get(HTML);
+        final JsonNode subsTrackHtml = subscriptionTracking.get(HTML);
         assertString(subTrackId + "." + HTML, false, subsTrackHtml);
 
-        JsonNode subsTrackTag = subscriptionTracking.get(SUBSTITUTION_TAG);
+        final JsonNode subsTrackTag = subscriptionTracking.get(SUBSTITUTION_TAG);
         assertString(subTrackId + "." + SUBSTITUTION_TAG, false, subsTrackTag);
       }
 
-      String gAnalyticsId = TRACKING_SETTINGS + "." + GANALYTICS;
-      JsonNode gAnalytics = trackingSettings.get(GANALYTICS);
-      assertObject(gAnalyticsId, false, gAnalytics);
+      final String ganalyticsId = TRACKING_SETTINGS + "." + GANALYTICS;
+      final JsonNode ganalytics = trackingSettings.get(GANALYTICS);
+      assertObject(ganalyticsId, false, ganalytics);
 
-      if (gAnalytics != null) {
-        JsonNode analyticsEnabled = gAnalytics.get(ENABLE);
-        assertBoolean(gAnalyticsId + "." + ENABLE, false, analyticsEnabled);
+      if (ganalytics != null) {
+        final JsonNode analyticsEnabled = ganalytics.get(ENABLE);
+        assertBoolean(ganalyticsId + "." + ENABLE, false, analyticsEnabled);
 
-        JsonNode utmSource = gAnalytics.get(UTM_SOURCE);
-        assertString(gAnalyticsId + "." + UTM_SOURCE, false, utmSource);
+        final JsonNode utmSource = ganalytics.get(UTM_SOURCE);
+        assertString(ganalyticsId + "." + UTM_SOURCE, false, utmSource);
 
-        JsonNode utmMedium = gAnalytics.get(UTM_MEDIUM);
-        assertString(gAnalyticsId + "." + UTM_MEDIUM, false, utmMedium);
+        final JsonNode utmMedium = ganalytics.get(UTM_MEDIUM);
+        assertString(ganalyticsId + "." + UTM_MEDIUM, false, utmMedium);
 
-        JsonNode utmTerm = gAnalytics.get(UTM_TERM);
-        assertString(gAnalyticsId + "." + UTM_TERM, false, utmTerm);
+        final JsonNode utmTerm = ganalytics.get(UTM_TERM);
+        assertString(ganalyticsId + "." + UTM_TERM, false, utmTerm);
 
-        JsonNode utmContent = gAnalytics.get(UTM_CONTENT);
-        assertString(gAnalyticsId + "." + UTM_CONTENT, false, utmContent);
+        final JsonNode utmContent = ganalytics.get(UTM_CONTENT);
+        assertString(ganalyticsId + "." + UTM_CONTENT, false, utmContent);
 
-        JsonNode utmCampaign = gAnalytics.get(UTM_CAMPAIGN);
-        assertString(gAnalyticsId + "." + UTM_CAMPAIGN, false, utmCampaign);
+        final JsonNode utmCampaign = ganalytics.get(UTM_CAMPAIGN);
+        assertString(ganalyticsId + "." + UTM_CAMPAIGN, false, utmCampaign);
       }
     }
   }
 
-  private void assertNameAndEmail(@NotNull JsonNode root, @NotNull String base) throws TypeCheckException {
+  private void assertNameAndEmail(JsonNode root,  String base)
+      throws TypeCheckException {
     assertString(base + "." + EMAIL, true, root.get(EMAIL));
     assertString(base + "." + NAME, false, root.get(NAME));
   }

--- a/src/main/java/com/sendgrid/typechecker/TypeChecker.java
+++ b/src/main/java/com/sendgrid/typechecker/TypeChecker.java
@@ -1,0 +1,330 @@
+package com.sendgrid.typechecker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sendgrid.Request;
+import com.sun.istack.internal.NotNull;
+import com.sun.istack.internal.Nullable;
+
+import java.io.IOException;
+
+import static com.sendgrid.typechecker.MailFieldIds.*;
+import static com.sendgrid.typechecker.TypeAsserts.*;
+
+public class TypeChecker {
+
+  public void checkRequest(@NotNull Request request) throws TypeCheckException, IOException {
+    String endpoint = request.getEndpoint();
+
+    switch (endpoint) {
+      case "mail/send": {
+        String body = request.getBody();
+        checkMailParams(body);
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  }
+
+  public void checkMailParams(@Nullable String body) throws TypeCheckException, IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode root = objectMapper.readTree(body);
+    if (root == null) throw new TypeCheckException("No body detected");
+
+    checkPersonalizations(root);
+
+    JsonNode from = root.get(FROM);
+    assertObject(FROM, true, from);
+
+    if (from != null) {
+      assertNameAndEmail(from, FROM);
+    }
+
+    JsonNode to = root.get(REPLY_TO);
+    assertObject(REPLY_TO, false, to);
+
+    if (to != null) {
+      assertNameAndEmail(to, REPLY_TO);
+    }
+
+    JsonNode subject = root.get(SUBJECT);
+    assertString(SUBJECT, false, subject);
+
+    checkContent(root);
+
+    checkAttachments(root);
+
+    JsonNode templateId = root.get(TEMPLATE_ID);
+    assertString(TEMPLATE_ID, false, templateId);
+
+    JsonNode ipPoolName = root.get(IP_POOL_NAME);
+    assertString(IP_POOL_NAME, false, ipPoolName);
+
+    JsonNode categories = root.get(CATEGORIES);
+    assertStringArray(CATEGORIES, false, categories);
+
+    JsonNode customArgs = root.get(CUSTOM_ARGS);
+    assertObject(CUSTOM_ARGS, false, customArgs);
+
+    JsonNode sections = root.get(SECTIONS);
+    assertObject(SECTIONS, false, sections);
+
+    JsonNode headers = root.get(HEADERS);
+    assertObject(HEADERS, false, headers);
+
+    JsonNode sendAt = root.get(SEND_AT);
+    assertInteger(SEND_AT, false, sendAt);
+
+    JsonNode batchId = root.get(BATCH_ID);
+    assertString(BATCH_ID, false, batchId);
+
+    checkAsm(root);
+
+    checkMailSettings(root);
+
+    checkTrackingSettings(root);
+
+  }
+
+  private void checkPersonalizations(JsonNode root) throws TypeCheckException {
+    JsonNode personalizations = root.get(PERSONALIZATIONS);
+    assertObjectArray(PERSONALIZATIONS, true, personalizations);
+    if (personalizations != null) {
+      applyAssertions((el) -> {
+        JsonNode to = el.get(TO);
+        String personalizationsBase = PERSONALIZATIONS + ".";
+
+        assertObjectArray(personalizationsBase + TO, true, to);
+        if (to != null) {
+          applyAssertions((node) -> assertNameAndEmail(node, personalizationsBase + TO), to);
+        }
+
+        JsonNode cc = el.get(CC);
+        assertObjectArray(personalizationsBase + CC, false, cc);
+        if (cc != null) {
+          applyAssertions((node) -> assertNameAndEmail(node, personalizationsBase + CC), cc);
+        }
+
+        JsonNode bcc = el.get(BCC);
+        assertObjectArray(personalizationsBase + BCC, false, bcc);
+        if (bcc != null) {
+          applyAssertions((node) -> assertNameAndEmail(node, personalizationsBase + BCC), bcc);
+        }
+
+        JsonNode subject = el.get(SUBJECT);
+        assertString(personalizationsBase + SUBJECT, false, subject);
+
+        JsonNode headers = el.get(HEADERS);
+        assertObject(personalizationsBase + HEADERS, false, headers);
+
+        JsonNode substitutions = el.get(SUBSTITUTIONS);
+        assertObject(personalizationsBase + SUBSTITUTIONS, false, substitutions);
+
+        JsonNode customArgs = el.get(CUSTOM_ARGS);
+        assertObject(personalizationsBase + CUSTOM_ARGS, false, customArgs);
+
+        JsonNode sendAt = el.get(SEND_AT);
+        assertInteger(personalizationsBase + SEND_AT, false, sendAt);
+
+      }, personalizations);
+    }
+  }
+
+  private void checkContent(JsonNode root) throws TypeCheckException {
+    JsonNode content = root.get(CONTENT);
+    assertObjectArray(CONTENT, true, content);
+
+    if (content != null) {
+      applyAssertions((el) -> {
+        JsonNode contentType = el.get(TYPE);
+        assertString(CONTENT + "." + TYPE, true, contentType);
+
+        JsonNode contentValue = el.get(VALUE);
+        assertString(CONTENT + "." + VALUE, true, contentValue);
+      }, content);
+    }
+  }
+
+  private void checkAttachments(JsonNode root) throws TypeCheckException {
+    JsonNode attachments = root.get(ATTACHMENTS);
+    assertObjectArray(ATTACHMENTS, false, attachments);
+
+    if (attachments != null) {
+      applyAssertions((el) -> {
+        JsonNode attachmentsContent = el.get(CONTENT);
+        assertString(ATTACHMENTS + "." + CONTENT, true, attachmentsContent);
+
+        JsonNode attachmentsType = el.get(TYPE);
+        assertString(ATTACHMENTS + "." + TYPE, false, attachmentsType);
+
+        JsonNode attachmentsFilename = el.get(FILENAME);
+        assertString(ATTACHMENTS + "." + FILENAME, true, attachmentsFilename);
+
+        JsonNode attachmentsDisposition = el.get(DISPOSITION);
+        assertString(ATTACHMENTS + "." + DISPOSITION, false, attachmentsDisposition);
+
+        JsonNode attachmentsContentId = el.get(CONTENT_ID);
+        assertString(ATTACHMENTS + "." + CONTENT_ID, false, attachmentsContentId);
+      }, attachments);
+    }
+  }
+
+  private void checkAsm(JsonNode root) throws TypeCheckException {
+    JsonNode asm = root.get(ASM);
+    assertObject(ASM, false, asm);
+
+    if (asm != null) {
+      JsonNode asmGroupId = asm.get(GROUP_ID);
+      assertInteger(ASM + "." + GROUP_ID, true, asmGroupId);
+
+      JsonNode asmGroupsToDisplay = asm.get(GROUPS_TO_DISPLAY);
+      assertIntArray(ASM + "." + GROUPS_TO_DISPLAY, false, asmGroupsToDisplay);
+
+    }
+  }
+
+  private void checkMailSettings(JsonNode root) throws TypeCheckException {
+    JsonNode mailSettings = root.get(MAIL_SETTINGS);
+    assertObject(MAIL_SETTINGS, false, mailSettings);
+
+    if (mailSettings != null) {
+      JsonNode bcc = mailSettings.get(BCC);
+      assertObject(MAIL_SETTINGS + "." + BCC, false, bcc);
+
+      if (bcc != null) {
+        JsonNode bccEnable = bcc.get(ENABLE);
+        assertBoolean(MAIL_SETTINGS + "." + BCC + "." + ENABLE, false, bccEnable);
+
+        JsonNode bccEmail = bcc.get(EMAIL);
+        assertString(MAIL_SETTINGS + "." + BCC + "." + EMAIL, false, bccEmail);
+      }
+
+      JsonNode bypassListManagement = mailSettings.get(BYPASS_LIST_MANAGEMENT);
+      assertObject(MAIL_SETTINGS + "." + BYPASS_LIST_MANAGEMENT, false, bypassListManagement);
+
+      if (bypassListManagement != null) {
+        JsonNode bypassEnable = bypassListManagement.get(ENABLE);
+        assertBoolean(MAIL_SETTINGS + "." + BYPASS_LIST_MANAGEMENT + "." + ENABLE, false, bypassEnable);
+      }
+
+      JsonNode footer = mailSettings.get(FOOTER);
+      assertObject(MAIL_SETTINGS + "." + FOOTER, false, footer);
+
+      if (footer != null) {
+        JsonNode footerEnabled = footer.get(ENABLE);
+        assertBoolean(MAIL_SETTINGS + "." + FOOTER + "." + ENABLE, false, footerEnabled);
+
+        JsonNode footerText = footer.get(TEXT);
+        assertString(MAIL_SETTINGS + "." + FOOTER + "." + TEXT, false, footerText);
+
+        JsonNode footerHtml = footer.get(HTML);
+        assertString(MAIL_SETTINGS + "." + FOOTER + "." + HTML, false, footerHtml);
+      }
+
+      JsonNode sandbox = mailSettings.get(SANDBOX_MODE);
+      assertObject(MAIL_SETTINGS + "." + SANDBOX_MODE, false, sandbox);
+
+      if (sandbox != null) {
+        JsonNode sandboxEnabled = sandbox.get(ENABLE);
+        assertBoolean(MAIL_SETTINGS + "." + SANDBOX_MODE + "." + ENABLE, false, sandboxEnabled);
+      }
+
+      JsonNode spamCheck = mailSettings.get(SPAM_CHECK);
+      assertObject(MAIL_SETTINGS + "." + SPAM_CHECK, false, spamCheck);
+
+      if (spamCheck != null) {
+        JsonNode spamCheckEnabled = spamCheck.get(ENABLE);
+        assertBoolean(MAIL_SETTINGS + "." + SPAM_CHECK + "." + ENABLE, false, spamCheckEnabled);
+
+        JsonNode spamCheckThreshold = spamCheck.get(THRESHOLD);
+        assertInteger(MAIL_SETTINGS + "." + SPAM_CHECK + "." + THRESHOLD, false, spamCheckThreshold);
+
+        JsonNode spamCheckUrl = spamCheck.get(POST_TO_URL);
+        assertString(MAIL_SETTINGS + "." + SPAM_CHECK + "." + POST_TO_URL, false, spamCheckUrl);
+      }
+
+    }
+  }
+
+  private void checkTrackingSettings(JsonNode root) throws TypeCheckException {
+    JsonNode trackingSettings = root.get(TRACKING_SETTINGS);
+    assertObject(TRACKING_SETTINGS, false, trackingSettings);
+
+    if (trackingSettings != null) {
+      String clickTrackId = TRACKING_SETTINGS + "." + CLICK_TRACKING;
+      JsonNode clickTracking = trackingSettings.get(CLICK_TRACKING);
+      assertObject(clickTrackId, false, clickTracking);
+
+
+      if (clickTracking != null) {
+        JsonNode clickTrackingEnabled = clickTracking.get(ENABLE);
+        assertBoolean(clickTrackId + "." + ENABLE, false, clickTrackingEnabled);
+
+        JsonNode clickTrackingTextEnabled = clickTracking.get(ENABLE_TEXT);
+        assertBoolean(clickTrackId + "." + ENABLE_TEXT, false, clickTrackingTextEnabled);
+      }
+
+      String openTrackId = TRACKING_SETTINGS + "." + OPEN_TRACKING;
+      JsonNode openTracking = trackingSettings.get(OPEN_TRACKING);
+      assertObject(openTrackId, false, openTracking);
+
+      if (openTracking != null) {
+        JsonNode openTrackingEnabled = openTracking.get(ENABLE);
+        assertBoolean(openTrackId + "." + ENABLE, false, openTrackingEnabled);
+
+        JsonNode openTrackingTag = openTracking.get(SUBSTITUTION_TAG);
+        assertString(openTrackId + "." + SUBSTITUTION_TAG, false, openTrackingTag);
+      }
+
+      String subTrackId = TRACKING_SETTINGS + "." + SUBSCRIPTION_TRACKING;
+      JsonNode subscriptionTracking = trackingSettings.get(SUBSCRIPTION_TRACKING);
+      assertObject(subTrackId, false, subscriptionTracking);
+
+      if (subscriptionTracking != null) {
+        JsonNode subsTrackEnabled = subscriptionTracking.get(ENABLE);
+        assertBoolean(subTrackId + "." + ENABLE, false, subsTrackEnabled);
+
+        JsonNode subsTrackText = subscriptionTracking.get(TEXT);
+        assertString(subTrackId + "." + TEXT, false, subsTrackText);
+
+        JsonNode subsTrackHtml = subscriptionTracking.get(HTML);
+        assertString(subTrackId + "." + HTML, false, subsTrackHtml);
+
+        JsonNode subsTrackTag = subscriptionTracking.get(SUBSTITUTION_TAG);
+        assertString(subTrackId + "." + SUBSTITUTION_TAG, false, subsTrackTag);
+      }
+
+      String gAnalyticsId = TRACKING_SETTINGS + "." + GANALYTICS;
+      JsonNode gAnalytics = trackingSettings.get(GANALYTICS);
+      assertObject(gAnalyticsId, false, gAnalytics);
+
+      if (gAnalytics != null) {
+        JsonNode analyticsEnabled = gAnalytics.get(ENABLE);
+        assertBoolean(gAnalyticsId + "." + ENABLE, false, analyticsEnabled);
+
+        JsonNode utmSource = gAnalytics.get(UTM_SOURCE);
+        assertString(gAnalyticsId + "." + UTM_SOURCE, false, utmSource);
+
+        JsonNode utmMedium = gAnalytics.get(UTM_MEDIUM);
+        assertString(gAnalyticsId + "." + UTM_MEDIUM, false, utmMedium);
+
+        JsonNode utmTerm = gAnalytics.get(UTM_TERM);
+        assertString(gAnalyticsId + "." + UTM_TERM, false, utmTerm);
+
+        JsonNode utmContent = gAnalytics.get(UTM_CONTENT);
+        assertString(gAnalyticsId + "." + UTM_CONTENT, false, utmContent);
+
+        JsonNode utmCampaign = gAnalytics.get(UTM_CAMPAIGN);
+        assertString(gAnalyticsId + "." + UTM_CAMPAIGN, false, utmCampaign);
+      }
+    }
+  }
+
+  private void assertNameAndEmail(@NotNull JsonNode root, @NotNull String base) throws TypeCheckException {
+    assertString(base + "." + EMAIL, true, root.get(EMAIL));
+    assertString(base + "." + NAME, false, root.get(NAME));
+  }
+
+}

--- a/src/test/java/com/sendgrid/SendGridTest.java
+++ b/src/test/java/com/sendgrid/SendGridTest.java
@@ -1,5 +1,6 @@
 package com.sendgrid;
 
+import com.sendgrid.typechecker.TypeCheckException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +33,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void testConstructWithClient() throws IOException {
+  public void testConstructWithClient() throws IOException, TypeCheckException {
     Client client = mock(Client.class);
     SendGrid sg = new SendGrid(SENDGRID_API_KEY, client);
     Request request = new Request();
@@ -176,7 +177,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_access_settings_activity_get() throws IOException {
+  public void test_access_settings_activity_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -190,7 +191,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_access_settings_whitelist_post() throws IOException {
+  public void test_access_settings_whitelist_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -204,7 +205,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_access_settings_whitelist_get() throws IOException {
+  public void test_access_settings_whitelist_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -217,7 +218,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_access_settings_whitelist_delete() throws IOException {
+  public void test_access_settings_whitelist_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -231,7 +232,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_access_settings_whitelist__rule_id__get() throws IOException {
+  public void test_access_settings_whitelist__rule_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -244,7 +245,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_access_settings_whitelist__rule_id__delete() throws IOException {
+  public void test_access_settings_whitelist__rule_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -257,7 +258,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_alerts_post() throws IOException {
+  public void test_alerts_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -271,7 +272,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_alerts_get() throws IOException {
+  public void test_alerts_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -284,7 +285,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_alerts__alert_id__patch() throws IOException {
+  public void test_alerts__alert_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -298,7 +299,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_alerts__alert_id__get() throws IOException {
+  public void test_alerts__alert_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -311,7 +312,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_alerts__alert_id__delete() throws IOException {
+  public void test_alerts__alert_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -324,7 +325,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_api_keys_post() throws IOException {
+  public void test_api_keys_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -338,7 +339,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_api_keys_get() throws IOException {
+  public void test_api_keys_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -352,7 +353,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_api_keys__api_key_id__put() throws IOException {
+  public void test_api_keys__api_key_id__put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -366,7 +367,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_api_keys__api_key_id__patch() throws IOException {
+  public void test_api_keys__api_key_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -380,7 +381,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_api_keys__api_key_id__get() throws IOException {
+  public void test_api_keys__api_key_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -393,7 +394,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_api_keys__api_key_id__delete() throws IOException {
+  public void test_api_keys__api_key_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -406,7 +407,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups_post() throws IOException {
+  public void test_asm_groups_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -420,7 +421,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups_get() throws IOException {
+  public void test_asm_groups_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -434,7 +435,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__patch() throws IOException {
+  public void test_asm_groups__group_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -448,7 +449,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__get() throws IOException {
+  public void test_asm_groups__group_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -461,7 +462,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__delete() throws IOException {
+  public void test_asm_groups__group_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -474,7 +475,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__suppressions_post() throws IOException {
+  public void test_asm_groups__group_id__suppressions_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -488,7 +489,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__suppressions_get() throws IOException {
+  public void test_asm_groups__group_id__suppressions_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -501,7 +502,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__suppressions_search_post() throws IOException {
+  public void test_asm_groups__group_id__suppressions_search_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -515,7 +516,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_groups__group_id__suppressions__email__delete() throws IOException {
+  public void test_asm_groups__group_id__suppressions__email__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -528,7 +529,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_suppressions_get() throws IOException {
+  public void test_asm_suppressions_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -541,7 +542,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_suppressions_global_post() throws IOException {
+  public void test_asm_suppressions_global_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -555,7 +556,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_suppressions_global__email__get() throws IOException {
+  public void test_asm_suppressions_global__email__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -568,7 +569,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_suppressions_global__email__delete() throws IOException {
+  public void test_asm_suppressions_global__email__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -581,7 +582,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_asm_suppressions__email__get() throws IOException {
+  public void test_asm_suppressions__email__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -594,7 +595,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_browsers_stats_get() throws IOException {
+  public void test_browsers_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -613,7 +614,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns_post() throws IOException {
+  public void test_campaigns_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -627,7 +628,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns_get() throws IOException {
+  public void test_campaigns_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -642,7 +643,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__patch() throws IOException {
+  public void test_campaigns__campaign_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -656,7 +657,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__get() throws IOException {
+  public void test_campaigns__campaign_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -669,7 +670,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__delete() throws IOException {
+  public void test_campaigns__campaign_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -682,7 +683,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__schedules_patch() throws IOException {
+  public void test_campaigns__campaign_id__schedules_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -696,7 +697,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__schedules_post() throws IOException {
+  public void test_campaigns__campaign_id__schedules_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -710,7 +711,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__schedules_get() throws IOException {
+  public void test_campaigns__campaign_id__schedules_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -723,7 +724,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__schedules_delete() throws IOException {
+  public void test_campaigns__campaign_id__schedules_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -736,7 +737,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__schedules_now_post() throws IOException {
+  public void test_campaigns__campaign_id__schedules_now_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -749,7 +750,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_campaigns__campaign_id__schedules_test_post() throws IOException {
+  public void test_campaigns__campaign_id__schedules_test_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -763,7 +764,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_categories_get() throws IOException {
+  public void test_categories_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -779,7 +780,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_categories_stats_get() throws IOException {
+  public void test_categories_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -798,7 +799,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_categories_stats_sums_get() throws IOException {
+  public void test_categories_stats_sums_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -818,7 +819,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_clients_stats_get() throws IOException {
+  public void test_clients_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -834,7 +835,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_clients__client_type__stats_get() throws IOException {
+  public void test_clients__client_type__stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -850,7 +851,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_custom_fields_post() throws IOException {
+  public void test_contactdb_custom_fields_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -864,7 +865,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_custom_fields_get() throws IOException {
+  public void test_contactdb_custom_fields_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -877,7 +878,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_custom_fields__custom_field_id__get() throws IOException {
+  public void test_contactdb_custom_fields__custom_field_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -890,7 +891,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_custom_fields__custom_field_id__delete() throws IOException {
+  public void test_contactdb_custom_fields__custom_field_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "202");
@@ -903,7 +904,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists_post() throws IOException {
+  public void test_contactdb_lists_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -917,7 +918,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists_get() throws IOException {
+  public void test_contactdb_lists_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -930,7 +931,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists_delete() throws IOException {
+  public void test_contactdb_lists_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -944,7 +945,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__patch() throws IOException {
+  public void test_contactdb_lists__list_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -959,7 +960,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__get() throws IOException {
+  public void test_contactdb_lists__list_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -973,7 +974,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__delete() throws IOException {
+  public void test_contactdb_lists__list_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "202");
@@ -987,7 +988,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__recipients_post() throws IOException {
+  public void test_contactdb_lists__list_id__recipients_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1001,7 +1002,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__recipients_get() throws IOException {
+  public void test_contactdb_lists__list_id__recipients_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1017,7 +1018,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__recipients__recipient_id__post() throws IOException {
+  public void test_contactdb_lists__list_id__recipients__recipient_id__post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1030,7 +1031,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_lists__list_id__recipients__recipient_id__delete() throws IOException {
+  public void test_contactdb_lists__list_id__recipients__recipient_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1045,7 +1046,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_patch() throws IOException {
+  public void test_contactdb_recipients_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1059,7 +1060,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_post() throws IOException {
+  public void test_contactdb_recipients_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1073,7 +1074,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_get() throws IOException {
+  public void test_contactdb_recipients_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1088,7 +1089,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_delete() throws IOException {
+  public void test_contactdb_recipients_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1102,7 +1103,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_billable_count_get() throws IOException {
+  public void test_contactdb_recipients_billable_count_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1115,7 +1116,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_count_get() throws IOException {
+  public void test_contactdb_recipients_count_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1128,7 +1129,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients_search_get() throws IOException {
+  public void test_contactdb_recipients_search_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1142,7 +1143,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients__recipient_id__get() throws IOException {
+  public void test_contactdb_recipients__recipient_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1155,7 +1156,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients__recipient_id__delete() throws IOException {
+  public void test_contactdb_recipients__recipient_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1168,7 +1169,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_recipients__recipient_id__lists_get() throws IOException {
+  public void test_contactdb_recipients__recipient_id__lists_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1181,7 +1182,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_reserved_fields_get() throws IOException {
+  public void test_contactdb_reserved_fields_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1194,7 +1195,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_segments_post() throws IOException {
+  public void test_contactdb_segments_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1208,7 +1209,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_segments_get() throws IOException {
+  public void test_contactdb_segments_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1221,7 +1222,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_segments__segment_id__patch() throws IOException {
+  public void test_contactdb_segments__segment_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1236,7 +1237,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_segments__segment_id__get() throws IOException {
+  public void test_contactdb_segments__segment_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1250,7 +1251,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_segments__segment_id__delete() throws IOException {
+  public void test_contactdb_segments__segment_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1264,7 +1265,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_contactdb_segments__segment_id__recipients_get() throws IOException {
+  public void test_contactdb_segments__segment_id__recipients_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1279,7 +1280,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_devices_stats_get() throws IOException {
+  public void test_devices_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1297,7 +1298,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_geo_stats_get() throws IOException {
+  public void test_geo_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1316,7 +1317,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_get() throws IOException {
+  public void test_ips_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1334,7 +1335,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_assigned_get() throws IOException {
+  public void test_ips_assigned_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1347,7 +1348,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools_post() throws IOException {
+  public void test_ips_pools_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1361,7 +1362,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools_get() throws IOException {
+  public void test_ips_pools_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1374,7 +1375,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools__pool_name__put() throws IOException {
+  public void test_ips_pools__pool_name__put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1388,7 +1389,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools__pool_name__get() throws IOException {
+  public void test_ips_pools__pool_name__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1401,7 +1402,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools__pool_name__delete() throws IOException {
+  public void test_ips_pools__pool_name__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1414,7 +1415,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools__pool_name__ips_post() throws IOException {
+  public void test_ips_pools__pool_name__ips_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1428,7 +1429,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_pools__pool_name__ips__ip__delete() throws IOException {
+  public void test_ips_pools__pool_name__ips__ip__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1441,7 +1442,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_warmup_post() throws IOException {
+  public void test_ips_warmup_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1455,7 +1456,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_warmup_get() throws IOException {
+  public void test_ips_warmup_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1468,7 +1469,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_warmup__ip_address__get() throws IOException {
+  public void test_ips_warmup__ip_address__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1481,7 +1482,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips_warmup__ip_address__delete() throws IOException {
+  public void test_ips_warmup__ip_address__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1494,7 +1495,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_ips__ip_address__get() throws IOException {
+  public void test_ips__ip_address__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1507,7 +1508,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_batch_post() throws IOException {
+  public void test_mail_batch_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1520,7 +1521,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_batch__batch_id__get() throws IOException {
+  public void test_mail_batch__batch_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1533,7 +1534,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_send_post() throws IOException {
+  public void test_mail_send_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "202");
@@ -1547,7 +1548,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_get() throws IOException {
+  public void test_mail_settings_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1562,7 +1563,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_address_whitelist_patch() throws IOException {
+  public void test_mail_settings_address_whitelist_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1576,7 +1577,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_address_whitelist_get() throws IOException {
+  public void test_mail_settings_address_whitelist_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1589,7 +1590,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_bcc_patch() throws IOException {
+  public void test_mail_settings_bcc_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1603,7 +1604,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_bcc_get() throws IOException {
+  public void test_mail_settings_bcc_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1616,7 +1617,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_bounce_purge_patch() throws IOException {
+  public void test_mail_settings_bounce_purge_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1630,7 +1631,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_bounce_purge_get() throws IOException {
+  public void test_mail_settings_bounce_purge_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1643,7 +1644,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_footer_patch() throws IOException {
+  public void test_mail_settings_footer_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1657,7 +1658,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_footer_get() throws IOException {
+  public void test_mail_settings_footer_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1670,7 +1671,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_forward_bounce_patch() throws IOException {
+  public void test_mail_settings_forward_bounce_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1684,7 +1685,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_forward_bounce_get() throws IOException {
+  public void test_mail_settings_forward_bounce_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1697,7 +1698,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_forward_spam_patch() throws IOException {
+  public void test_mail_settings_forward_spam_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1711,7 +1712,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_forward_spam_get() throws IOException {
+  public void test_mail_settings_forward_spam_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1724,7 +1725,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_plain_content_patch() throws IOException {
+  public void test_mail_settings_plain_content_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1738,7 +1739,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_plain_content_get() throws IOException {
+  public void test_mail_settings_plain_content_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1751,7 +1752,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_spam_check_patch() throws IOException {
+  public void test_mail_settings_spam_check_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1765,7 +1766,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_spam_check_get() throws IOException {
+  public void test_mail_settings_spam_check_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1778,7 +1779,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_template_patch() throws IOException {
+  public void test_mail_settings_template_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1792,7 +1793,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mail_settings_template_get() throws IOException {
+  public void test_mail_settings_template_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1805,7 +1806,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_mailbox_providers_stats_get() throws IOException {
+  public void test_mailbox_providers_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1824,7 +1825,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_partner_settings_get() throws IOException {
+  public void test_partner_settings_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1839,7 +1840,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_partner_settings_new_relic_patch() throws IOException {
+  public void test_partner_settings_new_relic_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1853,7 +1854,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_partner_settings_new_relic_get() throws IOException {
+  public void test_partner_settings_new_relic_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1866,7 +1867,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_scopes_get() throws IOException {
+  public void test_scopes_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1879,7 +1880,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_senders_post() throws IOException {
+  public void test_senders_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -1893,7 +1894,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_senders_get() throws IOException {
+  public void test_senders_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1906,7 +1907,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_senders__sender_id__patch() throws IOException {
+  public void test_senders__sender_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1920,7 +1921,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_senders__sender_id__get() throws IOException {
+  public void test_senders__sender_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1933,7 +1934,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_senders__sender_id__delete() throws IOException {
+  public void test_senders__sender_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1946,7 +1947,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_senders__sender_id__resend_verification_post() throws IOException {
+  public void test_senders__sender_id__resend_verification_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -1959,7 +1960,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_stats_get() throws IOException {
+  public void test_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1977,7 +1978,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers_post() throws IOException {
+  public void test_subusers_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -1991,7 +1992,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers_get() throws IOException {
+  public void test_subusers_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2007,7 +2008,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers_reputations_get() throws IOException {
+  public void test_subusers_reputations_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2021,7 +2022,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers_stats_get() throws IOException {
+  public void test_subusers_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2040,7 +2041,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers_stats_monthly_get() throws IOException {
+  public void test_subusers_stats_monthly_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2059,7 +2060,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers_stats_sums_get() throws IOException {
+  public void test_subusers_stats_sums_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2079,7 +2080,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__patch() throws IOException {
+  public void test_subusers__subuser_name__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2093,7 +2094,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__delete() throws IOException {
+  public void test_subusers__subuser_name__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2106,7 +2107,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__ips_put() throws IOException {
+  public void test_subusers__subuser_name__ips_put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2120,7 +2121,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__monitor_put() throws IOException {
+  public void test_subusers__subuser_name__monitor_put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2134,7 +2135,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__monitor_post() throws IOException {
+  public void test_subusers__subuser_name__monitor_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2148,7 +2149,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__monitor_get() throws IOException {
+  public void test_subusers__subuser_name__monitor_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2161,7 +2162,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__monitor_delete() throws IOException {
+  public void test_subusers__subuser_name__monitor_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2174,7 +2175,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_subusers__subuser_name__stats_monthly_get() throws IOException {
+  public void test_subusers__subuser_name__stats_monthly_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2192,7 +2193,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_blocks_get() throws IOException {
+  public void test_suppression_blocks_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2209,7 +2210,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_blocks_delete() throws IOException {
+  public void test_suppression_blocks_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2223,7 +2224,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_blocks__email__get() throws IOException {
+  public void test_suppression_blocks__email__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2236,7 +2237,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_blocks__email__delete() throws IOException {
+  public void test_suppression_blocks__email__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2249,7 +2250,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_bounces_get() throws IOException {
+  public void test_suppression_bounces_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2264,7 +2265,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_bounces_delete() throws IOException {
+  public void test_suppression_bounces_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2278,7 +2279,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_bounces__email__get() throws IOException {
+  public void test_suppression_bounces__email__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2291,7 +2292,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_bounces__email__delete() throws IOException {
+  public void test_suppression_bounces__email__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2305,7 +2306,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_invalid_emails_get() throws IOException {
+  public void test_suppression_invalid_emails_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2322,7 +2323,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_invalid_emails_delete() throws IOException {
+  public void test_suppression_invalid_emails_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2336,7 +2337,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_invalid_emails__email__get() throws IOException {
+  public void test_suppression_invalid_emails__email__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2349,7 +2350,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_invalid_emails__email__delete() throws IOException {
+  public void test_suppression_invalid_emails__email__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2362,7 +2363,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_spam_report__email__get() throws IOException {
+  public void test_suppression_spam_report__email__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2375,7 +2376,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_spam_report__email__delete() throws IOException {
+  public void test_suppression_spam_report__email__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2388,7 +2389,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_spam_reports_get() throws IOException {
+  public void test_suppression_spam_reports_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2405,7 +2406,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_spam_reports_delete() throws IOException {
+  public void test_suppression_spam_reports_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2419,7 +2420,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_suppression_unsubscribes_get() throws IOException {
+  public void test_suppression_unsubscribes_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2436,7 +2437,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates_post() throws IOException {
+  public void test_templates_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -2450,7 +2451,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates_get() throws IOException {
+  public void test_templates_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2463,7 +2464,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__patch() throws IOException {
+  public void test_templates__template_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2477,7 +2478,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__get() throws IOException {
+  public void test_templates__template_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2490,7 +2491,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__delete() throws IOException {
+  public void test_templates__template_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2503,7 +2504,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__versions_post() throws IOException {
+  public void test_templates__template_id__versions_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -2517,7 +2518,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__versions__version_id__patch() throws IOException {
+  public void test_templates__template_id__versions__version_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2531,7 +2532,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__versions__version_id__get() throws IOException {
+  public void test_templates__template_id__versions__version_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2544,7 +2545,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__versions__version_id__delete() throws IOException {
+  public void test_templates__template_id__versions__version_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2557,7 +2558,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_templates__template_id__versions__version_id__activate_post() throws IOException {
+  public void test_templates__template_id__versions__version_id__activate_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2570,7 +2571,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_get() throws IOException {
+  public void test_tracking_settings_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2585,7 +2586,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_click_patch() throws IOException {
+  public void test_tracking_settings_click_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2599,7 +2600,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_click_get() throws IOException {
+  public void test_tracking_settings_click_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2612,7 +2613,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_google_analytics_patch() throws IOException {
+  public void test_tracking_settings_google_analytics_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2626,7 +2627,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_google_analytics_get() throws IOException {
+  public void test_tracking_settings_google_analytics_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2639,7 +2640,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_open_patch() throws IOException {
+  public void test_tracking_settings_open_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2653,7 +2654,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_open_get() throws IOException {
+  public void test_tracking_settings_open_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2666,7 +2667,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_subscription_patch() throws IOException {
+  public void test_tracking_settings_subscription_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2680,7 +2681,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_tracking_settings_subscription_get() throws IOException {
+  public void test_tracking_settings_subscription_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2693,7 +2694,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_account_get() throws IOException {
+  public void test_user_account_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2706,7 +2707,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_credits_get() throws IOException {
+  public void test_user_credits_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2719,7 +2720,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_email_put() throws IOException {
+  public void test_user_email_put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2733,7 +2734,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_email_get() throws IOException {
+  public void test_user_email_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2746,7 +2747,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_password_put() throws IOException {
+  public void test_user_password_put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2760,7 +2761,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_profile_patch() throws IOException {
+  public void test_user_profile_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2774,7 +2775,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_profile_get() throws IOException {
+  public void test_user_profile_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2787,7 +2788,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_scheduled_sends_post() throws IOException {
+  public void test_user_scheduled_sends_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -2801,7 +2802,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_scheduled_sends_get() throws IOException {
+  public void test_user_scheduled_sends_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2814,7 +2815,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_scheduled_sends__batch_id__patch() throws IOException {
+  public void test_user_scheduled_sends__batch_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2828,7 +2829,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_scheduled_sends__batch_id__get() throws IOException {
+  public void test_user_scheduled_sends__batch_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2841,7 +2842,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_scheduled_sends__batch_id__delete() throws IOException {
+  public void test_user_scheduled_sends__batch_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2854,7 +2855,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_settings_enforced_tls_patch() throws IOException {
+  public void test_user_settings_enforced_tls_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2868,7 +2869,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_settings_enforced_tls_get() throws IOException {
+  public void test_user_settings_enforced_tls_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2881,7 +2882,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_username_put() throws IOException {
+  public void test_user_username_put() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2895,7 +2896,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_username_get() throws IOException {
+  public void test_user_username_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2908,7 +2909,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_event_settings_patch() throws IOException {
+  public void test_user_webhooks_event_settings_patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2922,7 +2923,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_event_settings_get() throws IOException {
+  public void test_user_webhooks_event_settings_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2935,7 +2936,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_event_test_post() throws IOException {
+  public void test_user_webhooks_event_test_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -2949,7 +2950,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_parse_settings_post() throws IOException {
+  public void test_user_webhooks_parse_settings_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -2963,7 +2964,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_parse_settings_get() throws IOException {
+  public void test_user_webhooks_parse_settings_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2976,7 +2977,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_parse_settings__hostname__patch() throws IOException {
+  public void test_user_webhooks_parse_settings__hostname__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -2990,7 +2991,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_parse_settings__hostname__get() throws IOException {
+  public void test_user_webhooks_parse_settings__hostname__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3003,7 +3004,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_parse_settings__hostname__delete() throws IOException {
+  public void test_user_webhooks_parse_settings__hostname__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -3016,7 +3017,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_user_webhooks_parse_stats_get() throws IOException {
+  public void test_user_webhooks_parse_stats_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3034,7 +3035,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains_post() throws IOException {
+  public void test_whitelabel_domains_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -3048,7 +3049,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains_get() throws IOException {
+  public void test_whitelabel_domains_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3066,7 +3067,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains_default_get() throws IOException {
+  public void test_whitelabel_domains_default_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3079,7 +3080,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains_subuser_get() throws IOException {
+  public void test_whitelabel_domains_subuser_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3092,7 +3093,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains_subuser_delete() throws IOException {
+  public void test_whitelabel_domains_subuser_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -3105,7 +3106,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__domain_id__patch() throws IOException {
+  public void test_whitelabel_domains__domain_id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3119,7 +3120,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__domain_id__get() throws IOException {
+  public void test_whitelabel_domains__domain_id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3132,7 +3133,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__domain_id__delete() throws IOException {
+  public void test_whitelabel_domains__domain_id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -3145,7 +3146,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__domain_id__subuser_post() throws IOException {
+  public void test_whitelabel_domains__domain_id__subuser_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -3159,7 +3160,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__id__ips_post() throws IOException {
+  public void test_whitelabel_domains__id__ips_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3173,7 +3174,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__id__ips__ip__delete() throws IOException {
+  public void test_whitelabel_domains__id__ips__ip__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3186,7 +3187,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_domains__id__validate_post() throws IOException {
+  public void test_whitelabel_domains__id__validate_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3199,7 +3200,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_ips_post() throws IOException {
+  public void test_whitelabel_ips_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -3213,7 +3214,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_ips_get() throws IOException {
+  public void test_whitelabel_ips_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3229,7 +3230,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_ips__id__get() throws IOException {
+  public void test_whitelabel_ips__id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3242,7 +3243,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_ips__id__delete() throws IOException {
+  public void test_whitelabel_ips__id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -3255,7 +3256,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_ips__id__validate_post() throws IOException {
+  public void test_whitelabel_ips__id__validate_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3268,7 +3269,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links_post() throws IOException {
+  public void test_whitelabel_links_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "201");
@@ -3284,7 +3285,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links_get() throws IOException {
+  public void test_whitelabel_links_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3298,7 +3299,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links_default_get() throws IOException {
+  public void test_whitelabel_links_default_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3312,7 +3313,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links_subuser_get() throws IOException {
+  public void test_whitelabel_links_subuser_get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3326,7 +3327,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links_subuser_delete() throws IOException {
+  public void test_whitelabel_links_subuser_delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -3340,7 +3341,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links__id__patch() throws IOException {
+  public void test_whitelabel_links__id__patch() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3354,7 +3355,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links__id__get() throws IOException {
+  public void test_whitelabel_links__id__get() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3367,7 +3368,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links__id__delete() throws IOException {
+  public void test_whitelabel_links__id__delete() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "204");
@@ -3380,7 +3381,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links__id__validate_post() throws IOException {
+  public void test_whitelabel_links__id__validate_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");
@@ -3393,7 +3394,7 @@ public class SendGridTest {
   }
 
   @Test
-  public void test_whitelabel_links__link_id__subuser_post() throws IOException {
+  public void test_whitelabel_links__link_id__subuser_post() throws IOException, TypeCheckException {
     SendGrid sg = new SendGrid("SENDGRID_API_KEY", true);
     sg.setHost("localhost:4010");
     sg.addRequestHeader("X-Mock", "200");

--- a/src/test/java/com/sendgrid/helpers/TypeAssertsTest.java
+++ b/src/test/java/com/sendgrid/helpers/TypeAssertsTest.java
@@ -155,27 +155,34 @@ public class TypeAssertsTest {
     String json = "[{\"a\":\"a\", \"b\":\"b\"}, {\"a\":\"c\", \"b\":\"d\"}]";
     JsonNode root = objectMapper.readTree(json);
 
-    TypeAsserts.applyAssertions((el) -> {
-      JsonNode a = el.get("a");
-      TypeAsserts.assertString("a", true, a);
+    TypeAsserts.applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+      @Override
+      public void accept(JsonNode el) throws TypeCheckException {
+        JsonNode a = el.get("a");
+        TypeAsserts.assertString("a", true, a);
 
-      JsonNode b = el.get("b");
-      TypeAsserts.assertString("b", true, b);
+        JsonNode b = el.get("b");
+        TypeAsserts.assertString("b", true, b);
+      }
     }, root);
   }
 
   @Test
-  public void test_apply_asserts_on_incorrect_object_not_ok() throws TypeCheckException, IOException {
+  public void test_apply_asserts_on_incorrect_object_not_ok()
+      throws TypeCheckException, IOException {
     String json = "[{\"a\":\"a\", \"b\":\"b\"}, {\"a\":\"c\"}]";
     JsonNode root = objectMapper.readTree(json);
 
     thrown.expect(TypeCheckException.class);
-    TypeAsserts.applyAssertions((el) -> {
-      JsonNode a = el.get("a");
-      TypeAsserts.assertString("a", true, a);
+    TypeAsserts.applyAssertions(new TypeAsserts.ThrowingConsumer<JsonNode, TypeCheckException>() {
+      @Override
+      public void accept(JsonNode el) throws TypeCheckException {
+        JsonNode a = el.get("a");
+        TypeAsserts.assertString("a", true, a);
 
-      JsonNode b = el.get("b");
-      TypeAsserts.assertString("b", true, b);
+        JsonNode b = el.get("b");
+        TypeAsserts.assertString("b", true, b);
+      }
     }, root);
   }
 

--- a/src/test/java/com/sendgrid/helpers/TypeAssertsTest.java
+++ b/src/test/java/com/sendgrid/helpers/TypeAssertsTest.java
@@ -1,0 +1,182 @@
+package com.sendgrid.helpers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sendgrid.typechecker.TypeAsserts;
+import com.sendgrid.typechecker.TypeCheckException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class TypeAssertsTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void test_null_object_throws() throws TypeCheckException {
+    Object o = null;
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertNotNull("object", o);
+  }
+
+  @Test
+  public void test_not_null_object_ok() throws TypeCheckException {
+    Object o = new Object();
+    TypeAsserts.assertNotNull("object", o);
+  }
+
+  @Test
+  public void test_not_string_throws() throws TypeCheckException {
+    JsonNode o = objectMapper.createObjectNode();
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertString("id", false, o);
+  }
+
+  @Test
+  public void test_required_null_string_throws() throws TypeCheckException {
+    JsonNode o = null;
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertString("id", true, o);
+  }
+
+  @Test
+  public void test_not_required_null_string_ok() throws TypeCheckException {
+    JsonNode o = null;
+    TypeAsserts.assertString("id", false, o);
+  }
+
+  @Test
+  public void test_parsed_value_is_string() throws TypeCheckException, IOException {
+    String json = "{\"field\":\"string_value\"}";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertString("id", true, node.get("field"));
+  }
+
+  @Test
+  public void test_parsed_number_is_ok() throws TypeCheckException, IOException {
+    String json = "{\"field\":1200}";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertInteger("id", true, node.get("field"));
+  }
+
+  @Test
+  public void test_too_big_int_throws() throws TypeCheckException, IOException {
+    String json = "{\"field\":\"3000000000\"}";
+    JsonNode node = objectMapper.readTree(json);
+
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertInteger("id", true, node.get("field"));
+  }
+
+  @Test
+  public void test_boolean_is_ok() throws TypeCheckException, IOException {
+    String json = "{\"field\":true}";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertBoolean("id", true, node.get("field"));
+  }
+
+  @Test
+  public void test_integer_as_boolean_is_not_ok() throws TypeCheckException, IOException {
+    String json = "{\"field\":1}";
+    JsonNode node = objectMapper.readTree(json);
+
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertBoolean("id", true, node.get("field"));
+  }
+
+  @Test
+  public void test_array_of_objects_is_ok() throws TypeCheckException, IOException {
+    String json = "[{\"name\":\"John Doe\"}, {\"email\":\"john@doe.com\"}]";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertObjectArray("id", true, node);
+  }
+
+  @Test
+  public void test_object_as_array_not_ok() throws TypeCheckException, IOException {
+    String json = "{\"name\":\"John Doe\"}";
+    JsonNode node = objectMapper.readTree(json);
+
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertObjectArray("id", true, node);
+  }
+
+  @Test
+  public void test_int_array_is_ok() throws TypeCheckException, IOException {
+    String json = "[1, 2, 3, 4]";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertIntArray("id", true, node);
+  }
+
+  @Test
+  public void test_string_array_is_not_int_array() throws TypeCheckException, IOException {
+    String json = "[\"a\", \"b\", \"c\", \"d\"]";
+    JsonNode node = objectMapper.readTree(json);
+
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertIntArray("id", true, node);
+  }
+
+  @Test
+  public void test_string_array_is_ok() throws TypeCheckException, IOException {
+    String json = "[\"a\", \"b\", \"c\", \"d\"]";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertStringArray("id", true, node);
+  }
+
+  @Test
+  public void test_int_array_is_not_string_array() throws TypeCheckException, IOException {
+    String json = "[1, 2, 3, 4]";
+    JsonNode node = objectMapper.readTree(json);
+
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.assertStringArray("id", true, node);
+  }
+
+  @Test
+  public void test_key_value_pairs_is_object_ok() throws TypeCheckException, IOException {
+    String json = "{\"a\":\"a\", \"b\":\"b\", \"c\":\"c\", \"d\":\"d\"}";
+    JsonNode node = objectMapper.readTree(json);
+
+    TypeAsserts.assertObject("id", true, node);
+  }
+
+  @Test
+  public void test_apply_asserts_on_object_ok() throws TypeCheckException, IOException {
+    String json = "[{\"a\":\"a\", \"b\":\"b\"}, {\"a\":\"c\", \"b\":\"d\"}]";
+    JsonNode root = objectMapper.readTree(json);
+
+    TypeAsserts.applyAssertions((el) -> {
+      JsonNode a = el.get("a");
+      TypeAsserts.assertString("a", true, a);
+
+      JsonNode b = el.get("b");
+      TypeAsserts.assertString("b", true, b);
+    }, root);
+  }
+
+  @Test
+  public void test_apply_asserts_on_incorrect_object_not_ok() throws TypeCheckException, IOException {
+    String json = "[{\"a\":\"a\", \"b\":\"b\"}, {\"a\":\"c\"}]";
+    JsonNode root = objectMapper.readTree(json);
+
+    thrown.expect(TypeCheckException.class);
+    TypeAsserts.applyAssertions((el) -> {
+      JsonNode a = el.get("a");
+      TypeAsserts.assertString("a", true, a);
+
+      JsonNode b = el.get("b");
+      TypeAsserts.assertString("b", true, b);
+    }, root);
+  }
+
+}

--- a/src/test/java/com/sendgrid/helpers/TypeCheckerTest.java
+++ b/src/test/java/com/sendgrid/helpers/TypeCheckerTest.java
@@ -18,34 +18,34 @@ public class TypeCheckerTest {
 
   @Test
   public void test_example_ok() throws TypeCheckException, IOException {
-   String json = "{\n" +
-       "  \"personalizations\": [\n" +
-       "    {\n" +
-       "      \"to\": [\n" +
-       "        {\n" +
-       "          \"email\": \"john.doe@example.com\",\n" +
-       "          \"name\": \"John Doe\"\n" +
-       "        }\n" +
-       "      ],\n" +
-       "      \"subject\": \"Hello, World!\"\n" +
-       "    }\n" +
-       "  ],\n" +
+    String json = "{\n" +
+        "  \"personalizations\": [\n" +
+        "    {\n" +
+        "      \"to\": [\n" +
+        "        {\n" +
+        "          \"email\": \"john.doe@example.com\",\n" +
+        "          \"name\": \"John Doe\"\n" +
+        "        }\n" +
+        "      ],\n" +
+        "      \"subject\": \"Hello, World!\"\n" +
+        "    }\n" +
+        "  ],\n" +
 
-       "  \"from\": {\n" +
-       "    \"email\": \"sam.smith@example.com\",\n" +
-       "    \"name\": \"Sam Smith\"\n" +
-       "  },\n" +
-       "  \"reply_to\": {\n" +
-       "    \"email\": \"sam.smith@example.com\",\n" +
-       "    \"name\": \"Sam Smith\"\n" +
-       "  },\n" +
-       "  \"content\": [\n" +
-       "    {\n" +
-       "      \"type\": \"text/plain\",\n" +
-       "      \"value\": \"Hello, World!\"\n" +
-       "    }\n" +
-       "  ]\n" +
-       "}";
+        "  \"from\": {\n" +
+        "    \"email\": \"sam.smith@example.com\",\n" +
+        "    \"name\": \"Sam Smith\"\n" +
+        "  },\n" +
+        "  \"reply_to\": {\n" +
+        "    \"email\": \"sam.smith@example.com\",\n" +
+        "    \"name\": \"Sam Smith\"\n" +
+        "  },\n" +
+        "  \"content\": [\n" +
+        "    {\n" +
+        "      \"type\": \"text/plain\",\n" +
+        "      \"value\": \"Hello, World!\"\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
 
     typeChecker.checkMailParams(json);
   }
@@ -108,7 +108,6 @@ public class TypeCheckerTest {
     thrown.expect(TypeCheckException.class);
     typeChecker.checkMailParams(json);
   }
-
 
 
 }

--- a/src/test/java/com/sendgrid/helpers/TypeCheckerTest.java
+++ b/src/test/java/com/sendgrid/helpers/TypeCheckerTest.java
@@ -1,0 +1,114 @@
+package com.sendgrid.helpers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sendgrid.typechecker.TypeCheckException;
+import com.sendgrid.typechecker.TypeChecker;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+
+public class TypeCheckerTest {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final TypeChecker typeChecker = new TypeChecker();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void test_example_ok() throws TypeCheckException, IOException {
+   String json = "{\n" +
+       "  \"personalizations\": [\n" +
+       "    {\n" +
+       "      \"to\": [\n" +
+       "        {\n" +
+       "          \"email\": \"john.doe@example.com\",\n" +
+       "          \"name\": \"John Doe\"\n" +
+       "        }\n" +
+       "      ],\n" +
+       "      \"subject\": \"Hello, World!\"\n" +
+       "    }\n" +
+       "  ],\n" +
+
+       "  \"from\": {\n" +
+       "    \"email\": \"sam.smith@example.com\",\n" +
+       "    \"name\": \"Sam Smith\"\n" +
+       "  },\n" +
+       "  \"reply_to\": {\n" +
+       "    \"email\": \"sam.smith@example.com\",\n" +
+       "    \"name\": \"Sam Smith\"\n" +
+       "  },\n" +
+       "  \"content\": [\n" +
+       "    {\n" +
+       "      \"type\": \"text/plain\",\n" +
+       "      \"value\": \"Hello, World!\"\n" +
+       "    }\n" +
+       "  ]\n" +
+       "}";
+
+    typeChecker.checkMailParams(json);
+  }
+
+  @Test
+  public void test_no_personalizations_error() throws TypeCheckException, IOException {
+    String json = "{\n" +
+        "  \"from\": {\n" +
+        "    \"email\": \"sam.smith@example.com\",\n" +
+        "    \"name\": \"Sam Smith\"\n" +
+        "  },\n" +
+        "  \"reply_to\": {\n" +
+        "    \"email\": \"sam.smith@example.com\",\n" +
+        "    \"name\": \"Sam Smith\"\n" +
+        "  },\n" +
+        "  \"content\": [\n" +
+        "    {\n" +
+        "      \"type\": \"text/plain\",\n" +
+        "      \"value\": \"Hello, World!\"\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    thrown.expect(TypeCheckException.class);
+    typeChecker.checkMailParams(json);
+  }
+
+  @Test
+  public void test_wrong_type_send_at_error() throws TypeCheckException, IOException {
+    String json = "{\n" +
+        "  \"personalizations\": [\n" +
+        "    {\n" +
+        "      \"to\": [\n" +
+        "        {\n" +
+        "          \"email\": \"john.doe@example.com\",\n" +
+        "          \"name\": \"John Doe\"\n" +
+        "        }\n" +
+        "      ],\n" +
+        "      \"subject\": \"Hello, World!\",\n" +
+        "      \"send_at\": \"Hello, World!\"\n" +
+        "    }\n" +
+        "  ],\n" +
+
+        "  \"from\": {\n" +
+        "    \"email\": \"sam.smith@example.com\",\n" +
+        "    \"name\": \"Sam Smith\"\n" +
+        "  },\n" +
+        "  \"reply_to\": {\n" +
+        "    \"email\": \"sam.smith@example.com\",\n" +
+        "    \"name\": \"Sam Smith\"\n" +
+        "  },\n" +
+        "  \"content\": [\n" +
+        "    {\n" +
+        "      \"type\": \"text/plain\",\n" +
+        "      \"value\": \"Hello, World!\"\n" +
+        "    }\n" +
+        "  ]\n" +
+        "}";
+
+    thrown.expect(TypeCheckException.class);
+    typeChecker.checkMailParams(json);
+  }
+
+
+
+}


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 
Resolves #510 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Added runtime check for requests sent to `mail/send` endpoint. If field value type is incorrect or missing while required user will get appropriate error and it's path. I.e., if user sends `send_at` in personalizations param as string instead of error, he will see message:
 `Field: personalizations.send_at contents must be of type Integer`
- Added tests for covering checks