### PR TITLE
docs: Fix whitespace errors and typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -4,11 +4,11 @@ We appreciate the effort for this pull request but before that please make sure 
 **All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**
 
 Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
-e.g. 
+e.g.
 Fixes #1
 Closes #2
 -->
-# Fixes # 
+# Fixes
 
 ### Checklist
 - [ ] I acknowledge that all my contributions will be made under the project's license
@@ -20,7 +20,7 @@ Closes #2
 - [ ] I have added in line documentation to the code I modified
 
 ### Short description of what this PR does:
-- 
-- 
+-
+-
 
-If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
+If you have questions, please send an email to [SendGrid](mailto:dx@sendgrid.com), or file a GitHub Issue in this repository.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,42 +1,42 @@
- 
+
  # Twilio SendGrid Community Code of Conduct
- 
-  The Twilio SendGrid open source community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines, which help steer our interactions and strive to maintain a positive, successful and growing community. 
- 
+
+  The Twilio SendGrid open source community is made up of members from around the globe with a diverse set of skills, personalities, and experiences. It is through these differences that our community experiences successes and continued growth. When you're working with members of the community, we encourage you to follow these guidelines, which help steer our interactions and strive to maintain a positive, successful and growing community.
+
  ### Be Open
  Members of the community are open to collaboration, whether it's on pull requests, code reviews, approvals, issues or otherwise. We're receptive to constructive comments and criticism, as the experiences and skill sets of all members contribute to the whole of our efforts. We're accepting of all who wish to take part in our activities, fostering an environment where anyone can participate, and everyone can make a difference.
- 
+
  ### Be Considerate
  Members of the community are considerate of their peers, which include other contributors and users of Twilio SendGrid. We're thoughtful when addressing the efforts of others, keeping in mind that often the labor was completed with the intent of the good of the community. We're attentive in our communications, whether in person or online, and we're tactful when approaching differing views.
- 
+
  ### Be Respectful
  Members of the community are respectful. We're respectful of others, their positions, their skills, their commitments and their efforts. We're respectful of the volunteer efforts that permeate the Twilio SendGrid community. We're respectful of the processes outlined in the community, and we work within them. When we disagree, we are courteous in raising our issues.  Overall, we're good to each other. We contribute to this community not because we have to, but because we want to. If we remember that, these guidelines will come naturally.
- 
- ## Additional Guidance 
- 
+
+ ## Additional Guidance
+
  ### Disclose Potential Conflicts of Interest
  Community discussions often involve interested parties. We expect participants to be aware when they are conflicted due to employment or other projects they are involved in and disclose those interests to other project members. When in doubt, over-disclose. Perceived conflicts of interest are important to address so that the community’s decisions are credible even when unpopular, difficult or favorable to the interests of one group over another.
- 
+
  ### Interpretation
- This Code is not exhaustive or complete. It is not a rulebook; it serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter.  When in doubt, try to abide by [Twilio SendGrid’s cultural values](https://sendgrid.com/blog/employee-engagement-the-4h-way) defined by our “4H’s”: Happy, Hungry, Humble and Honest.  
- 
+ This Code is not exhaustive or complete. It is not a rulebook; it serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter.  When in doubt, try to abide by [Twilio SendGrid’s cultural values](https://sendgrid.com/blog/employee-engagement-the-4h-way) defined by our “4H’s”: Happy, Hungry, Humble and Honest.
+
  ### Enforcement
  Most members of the Twilio SendGrid community always comply with this Code, not because of the existence of this Code, but because they have long experience participating in open source communities where the conduct described above is normal and expected. However, failure to observe this Code may be grounds for suspension, reporting the user for abuse or changing permissions for outside contributors.
- 
+
  ## If you have concerns about someone’s conduct
  **Initiate Direct Contact** - It is always appropriate to email a community member (if contact information is available), mention that you think their behavior was out of line, and (if necessary) point them to this Code.
- 
+
  **Discuss Publicly** - Discussing publicly is always acceptable. Note, though, that approaching the person directly may be better, as it tends to make them less defensive, and it respects the time of other community members, so you probably want to try direct contact first.
- 
+
  **Contact the Moderators** - You can reach the Twilio SendGrid moderators by emailing dx@sendgrid.com.
- 
+
  ## Submission to Twilio SendGrid Repositories
- Finally, just a reminder, changes to the Twilio SendGrid repositories will only be accepted upon completion of the [Twilio SendGrid Contributor Agreement](https://cla.sendgrid.com). 
- 
+ Finally, just a reminder, changes to the Twilio SendGrid repositories will only be accepted upon completion of the [Twilio SendGrid Contributor Agreement](https://cla.sendgrid.com).
+
  ## Attribution
- 
+
  Twilio SendGrid thanks the following, on which it draws for content and inspiration:
- 
- * [Python Community Code of Conduct](https://www.python.org/psf/codeofconduct/)  
- * [Open Source Initiative General Code of Conduct](https://opensource.org/codeofconduct) 
- * [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct.html) 
+
+ * [Python Community Code of Conduct](https://www.python.org/psf/codeofconduct/)
+ * [Open Source Initiative General Code of Conduct](https://opensource.org/codeofconduct)
+ * [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ A software bug is a demonstrable issue in the code base. In order for us to diag
 
 Before you decide to create a new issue, please try the following:
 
-1. Check the Github issues tab if the identified issue has already been reported, if so, please add a +1 to the existing post.
+1. Check the GitHub issues tab if the identified issue has already been reported, if so, please add a +1 to the existing post.
 2. Update to the latest version of this code and check if issue has already been fixed
 3. Copy and fill in the Bug Report Template we have provided below
 
@@ -166,10 +166,10 @@ Please run your code through:
    ```bash
    # Clone your fork of the repo into the current directory
    git clone https://github.com/sendgrid/sendgrid-java
-   
+
    # Navigate to the newly cloned directory
    cd sendgrid-java
-   
+
    # Assign the original repo to a remote called "upstream"
    git remote add upstream https://github.com/sendgrid/sendgrid-java
    ```

--- a/README.md
+++ b/README.md
@@ -232,9 +232,10 @@ Please see our [troubleshooting guide](https://github.com/sendgrid/sendgrid-java
 
 sendgrid-java is guided and supported by the Twilio Developer Experience Team.
 
-Please email the Developer Experience Team [here](mailto:dx@sendgrid.com) in case of any queries. 
+Please email the Developer Experience Team [here](mailto:dx@sendgrid.com) in case of any queries.
 
 sendgrid-java is maintained and funded by Twilio SendGrid, Inc. The names and logos for sendgrid-java are trademarks of Twilio SendGrid, Inc.
 
 # License
+
 [The MIT License (MIT)](LICENSE.md)


### PR DESCRIPTION
Just a few whitespace error fixes in the markdown files, as well as two typo fixes:

- `Github` -> `GitHub`
- `Sendgrid` -> `SendGrid`
