### PR TITLE
Remove references to "Whitelabel"

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,4 +237,4 @@ Please email the Developer Experience Team [here](mailto:dx@sendgrid.com) in cas
 sendgrid-java is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-java are trademarks of SendGrid, Inc.
 
 # License
-[The MIT License (MIT)](LICENSE.txt)
+[The MIT License (MIT)](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/sendgrid.svg?style=social&label=Follow)](https://twitter.com/sendgrid)
 [![GitHub contributors](https://img.shields.io/github/contributors/sendgrid/sendgrid-java.svg)](https://github.com/sendgrid/sendgrid-java/graphs/contributors)
 [![Open Source Helpers](https://www.codetriage.com/sendgrid/sendgrid-java/badges/users.svg)](https://www.codetriage.com/sendgrid/sendgrid-java)
-[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.txt)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE.md)
 
 **NEW:** Subscribe to email [notifications](https://dx.sendgrid.com/newsletter/java) for releases and breaking changes.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -40,13 +40,13 @@ public class Example {
 * [PARTNER SETTINGS](#partner-settings)
 * [SCOPES](#scopes)
 * [SENDERS](#senders)
+* [SENDER AUTHENTICATION](#sender-authentication)
 * [STATS](#stats)
 * [SUBUSERS](#subusers)
 * [SUPPRESSION](#suppression)
 * [TEMPLATES](#templates)
 * [TRACKING SETTINGS](#tracking-settings)
 * [USER](#user)
-* [WHITELABEL](#whitelabel)
 
 
 <a name="access-settings"></a>
@@ -2258,7 +2258,7 @@ Advanced Stats provide a more in-depth view of your email statistics and the act
 
 **This endpoint allows you to retrieve a list of all assigned and unassigned IPs.**
 
-Response includes warm up status, pools, assigned subusers, and whitelabel info. The start_date field corresponds to when warmup started for that IP.
+Response includes warm up status, pools, assigned subusers, and authorization info. The start_date field corresponds to when warmup started for that IP.
 
 A single IP address or a range of IP addresses may be dedicated to an account in order to send email for multiple domains. The reputation of this IP is based on the aggregate performance of all the senders who use it.
 
@@ -3349,7 +3349,7 @@ API Keys can be used to authenticate the use of [SendGrids v3 Web API](https://s
 
 *You may create up to 100 unique sender identities.*
 
-Sender Identities are required to be verified before use. If your domain has been whitelabeled it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
+Sender Identities are required to be verified before use. If your domain has been authorized, it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
 
 ### POST /senders
 
@@ -3373,7 +3373,7 @@ Sender Identities are required to be verified before use. If your domain has bee
 
 **This endpoint allows you to retrieve a list of all sender identities that have been created for your account.**
 
-Sender Identities are required to be verified before use. If your domain has been whitelabeled it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
+Sender Identities are required to be verified before use. If your domain has been authorized, it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
 
 ### GET /senders
 
@@ -3396,7 +3396,7 @@ Sender Identities are required to be verified before use. If your domain has bee
 
 **This endpoint allows you to update a sender identity.**
 
-Updates to `from.email` require re-verification. If your domain has been whitelabeled it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
+Updates to `from.email` require re-verification. If your domain has been authorized, it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
 
 Partial updates are allowed, but fields that are marked as "required" in the POST (create) endpoint must not be nil if that field is included in the PATCH request.
 
@@ -3422,7 +3422,7 @@ Partial updates are allowed, but fields that are marked as "required" in the POS
 
 **This endpoint allows you to retrieve a specific sender identity.**
 
-Sender Identities are required to be verified before use. If your domain has been whitelabeled it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
+Sender Identities are required to be verified before use. If your domain has been authorized, it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
 
 ### GET /senders/{sender_id}
 
@@ -3445,7 +3445,7 @@ Sender Identities are required to be verified before use. If your domain has bee
 
 **This endpoint allows you to delete one of your sender identities.**
 
-Sender Identities are required to be verified before use. If your domain has been whitelabeled it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
+Sender Identities are required to be verified before use. If your domain has been authorized, it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
 
 ### DELETE /senders/{sender_id}
 
@@ -3468,7 +3468,7 @@ Sender Identities are required to be verified before use. If your domain has bee
 
 **This endpoint allows you to resend a sender identity verification email.**
 
-Sender Identities are required to be verified before use. If your domain has been whitelabeled it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
+Sender Identities are required to be verified before use. If your domain has been authorized, it will auto verify on creation. Otherwise an email will be sent to the `from.email`.
 
 ### POST /senders/{sender_id}/resend_verification
 
@@ -3487,6 +3487,777 @@ Sender Identities are required to be verified before use. If your domain has bee
     throw ex;
   }
   ```
+<a name="sender-authentication"></a>
+# SENDER AUTHENTICATION
+
+## Create an authenticated domain.
+
+**This endpoint allows you to create a domain authentication for one of your domains.**
+
+If you are creating a domain authentication that you would like a subuser to use, you have two options:
+1. Use the "username" parameter. This allows you to create am authenticated subuser. This means the subuser is able to see and modify the created authentication.
+2. Use the Association workflow (see Associate Domain section). This allows you to assign a domain authentication created by the parent to a subuser. This means the subuser will default to the assigned domain authentication, but will not be able to see or modify that authentication. However, if the subuser creates their own domain authentication it will overwrite the assigned domain authentication.
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+### POST /whitelabel/domains
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains");
+    request.setBody("{\"automatic)_security\":false,\"username\":\"john@example.com\",\"domain\":\"example.com\",\"default\":true,\"custom_spf\":true,\"ips\":[\"192.168.1.1\",\"192.168.1.2\"],\"subdomain\":\"news\"}";
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## List all domain authentications.
+
+**This endpoint allows you to retrieve a list of all domain authentications you have created.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+### GET /whitelabel/domains
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains");
+    request.addQueryParam("username", "test_string");
+      request.addQueryParam("domain", "test_string");
+      request.addQueryParam("exclude_subusers", "true");
+      request.addQueryParam("limit", "1");
+      request.addQueryParam("offset", "1");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Get the default domain authentication.
+
+**This endpoint allows you to retrieve the default authentication for a domain.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type   | Description  |
+|---|---|---|
+| domain | string  |The domain to find a default domain whitelabel for. |
+
+### GET /whitelabel/domains/default
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains/default");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## List the domain authentication associated with the given user.
+
+**This endpoint allows you to retrieve all of the domain authentications that have been assigned to a specific subuser.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+Domain authentications can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's authenticated domains. To associate a domain authentication with a subuser, the parent account must first create the domain authentication and validate it. The parent may then associate the domain authentication via the subuser management tools.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type  | Description  |
+|---|---|---|
+| username | string  | Username of the subuser to find associated whitelabels for. |
+
+### GET /whitelabel/domains/subuser
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains/subuser");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Disassociate a domain authentication from a given user.
+
+**This endpoint allows you to disassociate a specific domain authentication from a subuser.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+Domain authentications can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's authenticated domains. To associate a domain authentication with a subuser, the parent account must first create the domain authentication and validate it. The parent may then associate the domain authentication via the subuser management tools.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type  | Required?  | Description  |
+|---|---|---|---|
+| username | string  | required  | Username for the subuser to find associated whitelabels for. |
+
+### DELETE /whitelabel/domains/subuser
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/domains/subuser");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Update a domain authentication.
+
+**This endpoint allows you to update the settings for a domain authentication.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+### PATCH /whitelabel/domains/{domain_id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("whitelabel/domains/{domain_id}");
+    request.setBody("{\"default\":false,\"custom_spf\":true}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve a domain authentication.
+
+**This endpoint allows you to retrieve a specific domain authentication.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+
+### GET /whitelabel/domains/{domain_id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/domains/{domain_id}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Delete a domain authentication.
+
+**This endpoint allows you to delete a domain authentication.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+### DELETE /whitelabel/domains/{domain_id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/domains/{domain_id}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Associate a domain authentication with a given user.
+
+**This endpoint allows you to associate a specific domain authentication with a subuser.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+Domain authentications can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's authenticated domains. To associate a domain authentication with a subuser, the parent account must first create the domain authentication and validate it. The parent may then associate the domain authentication via the subuser management tools.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type   | Description  |
+|---|---|---|
+| domain_id | integer   | ID of the domain whitelabel to associate with the subuser. |
+
+### POST /whitelabel/domains/{domain_id}/subuser
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains/{domain_id}/subuser");
+    request.setBody("{\"username\":\"jane@example.com\"}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Add an IP to a domain authentication.
+
+**This endpoint allows you to add an IP address to a domain authentication.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type  |  Description  |
+|---|---|---|
+| id | integer  | ID of the domain to which you are adding an IP |
+
+### POST /whitelabel/domains/{id}/ips
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains/{id}/ips");
+    request.setBody("{\"ip\":\"192.168.0.1\"}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Remove an IP from a domain authenticaiton.
+
+**This endpoint allows you to remove a domain's IP address from that domain's authentication.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type  | Description  |
+|---|---|---|
+| id | integer  | ID of the domain whitelabel to delete the IP from. |
+| ip | string | IP to remove from the domain whitelabel. |
+
+### DELETE /whitelabel/domains/{id}/ips/{ip}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/domains/{id}/ips/{ip}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Validate a domain authentication.
+
+**This endpoint allows you to validate a domain authentication. If it fails, it will return an error message describing why the domain could not be validated.**
+
+A domain authentication allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Authenticating a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
+
+For more information on domain authentication, please see our [User Guide]((https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/)
+
+## URI Parameters
+| URI Parameter   | Type   | Description  |
+|---|---|---|
+| id | integer  |ID of the domain whitelabel to validate. |
+
+### POST /whitelabel/domains/{id}/validate
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/domains/{id}/validate");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Create reverse DNS
+
+**This endpoint allows you to create a reverse DNS record.**
+
+When creating a reverse DNS record, you should use the same subdomain that you used when you created a domain authentication.
+
+Reverse DNS consists of a subdomain and domain that will be used to generate a record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-reverse-dns/).
+
+### POST /whitelabel/ips
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/ips");
+    request.setBody("{\"ip\":\"192.168.1.1\",\"domain\":\"example.com\",\"subdomain\":\"email\"}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve all reverse DNS records
+
+**This endpoint allows you to retrieve all of the reverse DNS records that have been created by this account.**
+
+You may include a search key by using the "ip" parameter. This enables you to perform a prefix search for a given IP segment (e.g. "192.").
+
+Reverse DNS consists of a subdomain and domain that will be used to generate a record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-reverse-dns/).
+
+### GET /whitelabel/ips
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/ips");
+    request.addQueryParam("ip", "test_string");
+      request.addQueryParam("limit", "1");
+      request.addQueryParam("offset", "1");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve an reverse DNS record
+
+**This endpoint allows you to retrieve a reverse DNS record.**
+
+Reverse DNS consists of a subdomain and domain that will be used to generate a record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-reverse-dns/).
+
+### GET /whitelabel/ips/{id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/ips/{id}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Delete an reverse DNS record
+
+**This endpoint allows you to delete a reverse DNS record.**
+
+Reverse DNS consists of a subdomain and domain that will be used to generate a record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-reverse-dns/).
+
+### DELETE /whitelabel/ips/{id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/ips/{id}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Validate a reverse DNS record
+
+**This endpoint allows you to validate a reverse DNS record.**
+
+Reverse DNS consists of a subdomain and domain that will be used to generate a record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-reverse-dns/).
+
+### POST /whitelabel/ips/{id}/validate
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/ips/{id}/validate");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Create a Branded Link
+
+**This endpoint allows you to create a new link branding.**
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### POST /whitelabel/links
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/links");
+    request.setBody("{\"default\":true,\"domain\":\"example.com\",\"subdomain\":\"mail\"}");
+    request.addQueryParam("limit", "1");
+      request.addQueryParam("offset", "1");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve all link brandings
+
+**This endpoint allows you to retrieve all link brandings.**
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### GET /whitelabel/links
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links");
+    request.addQueryParam("limit", "1");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve a Default Link Branding
+
+**This endpoint allows you to retrieve the default link branding.**
+
+Default link branding is the actual link branding to be used when sending messages. If there are multiple link brandings, the default is determined by the following order:
+<ul>
+  <li>Validated link branding marked as "default"</li>
+  <li>Legacy link brands (migrated from the whitelabel wizard)</li>
+  <li>Default SendGrid link whitelabel (i.e. 100.ct.sendgrid.net)</li>
+</ul>
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### GET /whitelabel/links/default
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links/default");
+    request.addQueryParam("domain", "test_string");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve Associated Link Branding
+
+**This endpoint allows you to retrieve the associated link branding for a subuser.**
+
+Link branding can be associated with subusers from the parent account. This functionality allows
+subusers to send mail using their parent's link brands. To associate a link branding, the parent account
+must first create a branded link and validate it. The parent may then associate that branded link with a subuser via the API or the Subuser Management page in the user interface.
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### GET /whitelabel/links/subuser
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links/subuser");
+    request.addQueryParam("username", "test_string");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Disassociate a Link Branding
+
+**This endpoint allows you to disassociate a link branding from a subuser.**
+
+Link branding can be associated with subusers from the parent account. This functionality allows
+subusers to send mail using their parent's link brands. To associate a link branding, the parent account
+must first create a branded link and validate it. The parent may then associate that branded link with a subuser via the API or the Subuser Management page in the user interface.
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### DELETE /whitelabel/links/subuser
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/links/subuser");
+    request.addQueryParam("username", "test_string");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Update a Link Branding
+
+**This endpoint allows you to update a specific link branding. You can use this endpoint to change a branded link's default status.**
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### PATCH /whitelabel/links/{id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.PATCH);
+    request.setEndpoint("whitelabel/links/{id}");
+    request.setBody("{\"default\":true}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Retrieve a Link Branding
+
+**This endpoint allows you to retrieve a specific link branding.**
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### GET /whitelabel/links/{id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.GET);
+    request.setEndpoint("whitelabel/links/{id}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Delete a Link Branding
+
+**This endpoint allows you to delete a link branding.**
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### DELETE /whitelabel/links/{id}
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.DELETE);
+    request.setEndpoint("whitelabel/links/{id}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Validate a Link Branding
+
+**This endpoint allows you to validate a link branding.**
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### POST /whitelabel/links/{id}/validate
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/links/{id}/validate");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+## Associate a Link Branding
+
+**This endpoint allows you to associate a link whitelabel with a subuser account.**
+
+Link branding can be associated with subusers from the parent account. This functionality allows
+subusers to send mail using their parent's link brands. To associate a link branding, the parent account
+must first create a branded link and validate it. The parent may then associate that branded link with a subuser via the API or the Subuser Management page in the user interface.
+
+Email link branding allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
+
+For more information, please see our [User Guide](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-link-branding/).
+
+### POST /whitelabel/links/{link_id}/subuser
+
+
+```java
+  try {
+    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("whitelabel/links/{link_id}/subuser");
+    request.setBody("{\"username\":\"jane@example.com\"}");
+    Response response = sg.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  } catch (IOException ex) {
+    throw ex;
+  }
+  ```
+  
 <a name="stats"></a>
 # STATS
 
@@ -5572,775 +6343,3 @@ There are a number of pre-made integrations for the SendGrid Parse Webhook which
     throw ex;
   }
   ```
-<a name="whitelabel"></a>
-# WHITELABEL
-
-## Create a domain whitelabel.
-
-**This endpoint allows you to create a whitelabel for one of your domains.**
-
-If you are creating a domain whitelabel that you would like a subuser to use, you have two options:
-1. Use the "username" parameter. This allows you to create a whitelabel on behalf of your subuser. This means the subuser is able to see and modify the created whitelabel.
-2. Use the Association workflow (see Associate Domain section). This allows you to assign a whitelabel created by the parent to a subuser. This means the subuser will default to the assigned whitelabel, but will not be able to see or modify that whitelabel. However, if the subuser creates their own whitelabel it will overwrite the assigned whitelabel.
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-### POST /whitelabel/domains
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/domains");
-    request.setBody("{\"automatic)_security\":false,\"username\":\"john@example.com\",\"domain\":\"example.com\",\"default\":true,\"custom_spf\":true,\"ips\":[\"192.168.1.1\",\"192.168.1.2\"],\"subdomain\":\"news\"}";
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## List all domain whitelabels.
-
-**This endpoint allows you to retrieve a list of all domain whitelabels you have created.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-
-### GET /whitelabel/domains
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/domains");
-    request.addQueryParam("username", "test_string");
-      request.addQueryParam("domain", "test_string");
-      request.addQueryParam("exclude_subusers", "true");
-      request.addQueryParam("limit", "1");
-      request.addQueryParam("offset", "1");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Get the default domain whitelabel.
-
-**This endpoint allows you to retrieve the default whitelabel for a domain.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type   | Description  |
-|---|---|---|
-| domain | string  |The domain to find a default domain whitelabel for. |
-
-### GET /whitelabel/domains/default
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/domains/default");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## List the domain whitelabel associated with the given user.
-
-**This endpoint allows you to retrieve all of the whitelabels that have been assigned to a specific subuser.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-Domain whitelabels can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's whitelabels. To associate a whitelabel with a subuser, the parent account must first create the whitelabel and validate it. The parent may then associate the whitelabel via the subuser management tools.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type  | Description  |
-|---|---|---|
-| username | string  | Username of the subuser to find associated whitelabels for. |
-
-### GET /whitelabel/domains/subuser
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/domains/subuser");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Disassociate a domain whitelabel from a given user.
-
-**This endpoint allows you to disassociate a specific whitelabel from a subuser.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-Domain whitelabels can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's whitelabels. To associate a whitelabel with a subuser, the parent account must first create the whitelabel and validate it. The parent may then associate the whitelabel via the subuser management tools.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type  | Required?  | Description  |
-|---|---|---|---|
-| username | string  | required  | Username for the subuser to find associated whitelabels for. |
-
-### DELETE /whitelabel/domains/subuser
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.DELETE);
-    request.setEndpoint("whitelabel/domains/subuser");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Update a domain whitelabel.
-
-**This endpoint allows you to update the settings for a domain whitelabel.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-### PATCH /whitelabel/domains/{domain_id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.PATCH);
-    request.setEndpoint("whitelabel/domains/{domain_id}");
-    request.setBody("{\"default\":false,\"custom_spf\":true}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve a domain whitelabel.
-
-**This endpoint allows you to retrieve a specific domain whitelabel.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-
-### GET /whitelabel/domains/{domain_id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/domains/{domain_id}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Delete a domain whitelabel.
-
-**This endpoint allows you to delete a domain whitelabel.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-### DELETE /whitelabel/domains/{domain_id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.DELETE);
-    request.setEndpoint("whitelabel/domains/{domain_id}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Associate a domain whitelabel with a given user.
-
-**This endpoint allows you to associate a specific domain whitelabel with a subuser.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-Domain whitelabels can be associated with (i.e. assigned to) subusers from a parent account. This functionality allows subusers to send mail using their parent's whitelabels. To associate a whitelabel with a subuser, the parent account must first create the whitelabel and validate it. The parent may then associate the whitelabel via the subuser management tools.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type   | Description  |
-|---|---|---|
-| domain_id | integer   | ID of the domain whitelabel to associate with the subuser. |
-
-### POST /whitelabel/domains/{domain_id}/subuser
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/domains/{domain_id}/subuser");
-    request.setBody("{\"username\":\"jane@example.com\"}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Add an IP to a domain whitelabel.
-
-**This endpoint allows you to add an IP address to a domain whitelabel.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type  |  Description  |
-|---|---|---|
-| id | integer  | ID of the domain to which you are adding an IP |
-
-### POST /whitelabel/domains/{id}/ips
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/domains/{id}/ips");
-    request.setBody("{\"ip\":\"192.168.0.1\"}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Remove an IP from a domain whitelabel.
-
-**This endpoint allows you to remove a domain's IP address from that domain's whitelabel.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type  | Description  |
-|---|---|---|
-| id | integer  | ID of the domain whitelabel to delete the IP from. |
-| ip | string | IP to remove from the domain whitelabel. |
-
-### DELETE /whitelabel/domains/{id}/ips/{ip}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.DELETE);
-    request.setEndpoint("whitelabel/domains/{id}/ips/{ip}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Validate a domain whitelabel.
-
-**This endpoint allows you to validate a domain whitelabel. If it fails, it will return an error message describing why the whitelabel could not be validated.**
-
-A domain whitelabel allows you to remove the via or sent on behalf of message that your recipients see when they read your emails. Whitelabeling a domain allows you to replace sendgrid.net with your personal sending domain. You will be required to create a subdomain so that SendGrid can generate the DNS records which you must give to your host provider. If you choose to use Automated Security, SendGrid will provide you with 3 CNAME records. If you turn Automated Security off, you will be given 2 TXT records and 1 MX record.
-
-For more information on whitelabeling, please see our [User Guide](https://sendgrid.com/docs/User_Guide/Settings/Whitelabel/index.html)
-
-## URI Parameters
-| URI Parameter   | Type   | Description  |
-|---|---|---|
-| id | integer  |ID of the domain whitelabel to validate. |
-
-### POST /whitelabel/domains/{id}/validate
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/domains/{id}/validate");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Create an IP whitelabel
-
-**This endpoint allows you to create an IP whitelabel.**
-
-When creating an IP whitelable, you should use the same subdomain that you used when you created a domain whitelabel.
-
-A IP whitelabel consists of a subdomain and domain that will be used to generate a reverse DNS record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/ips.html).
-
-### POST /whitelabel/ips
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/ips");
-    request.setBody("{\"ip\":\"192.168.1.1\",\"domain\":\"example.com\",\"subdomain\":\"email\"}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve all IP whitelabels
-
-**This endpoint allows you to retrieve all of the IP whitelabels that have been created by this account.**
-
-You may include a search key by using the "ip" parameter. This enables you to perform a prefix search for a given IP segment (e.g. "192.").
-
-A IP whitelabel consists of a subdomain and domain that will be used to generate a reverse DNS record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/ips.html).
-
-### GET /whitelabel/ips
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/ips");
-    request.addQueryParam("ip", "test_string");
-      request.addQueryParam("limit", "1");
-      request.addQueryParam("offset", "1");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve an IP whitelabel
-
-**This endpoint allows you to retrieve an IP whitelabel.**
-
-A IP whitelabel consists of a subdomain and domain that will be used to generate a reverse DNS record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/ips.html).
-
-### GET /whitelabel/ips/{id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/ips/{id}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Delete an IP whitelabel
-
-**This endpoint allows you to delete an IP whitelabel.**
-
-A IP whitelabel consists of a subdomain and domain that will be used to generate a reverse DNS record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/ips.html).
-
-### DELETE /whitelabel/ips/{id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.DELETE);
-    request.setEndpoint("whitelabel/ips/{id}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Validate an IP whitelabel
-
-**This endpoint allows you to validate an IP whitelabel.**
-
-A IP whitelabel consists of a subdomain and domain that will be used to generate a reverse DNS record for a given IP. Once SendGrid has verified that the appropriate A record for the IP has been created, the appropriate reverse DNS record for the IP is generated.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/ips.html).
-
-### POST /whitelabel/ips/{id}/validate
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/ips/{id}/validate");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Create a Link Whitelabel
-
-**This endpoint allows you to create a new link whitelabel.**
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### POST /whitelabel/links
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/links");
-    request.setBody("{\"default\":true,\"domain\":\"example.com\",\"subdomain\":\"mail\"}");
-    request.addQueryParam("limit", "1");
-      request.addQueryParam("offset", "1");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve all link whitelabels
-
-**This endpoint allows you to retrieve all link whitelabels.**
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### GET /whitelabel/links
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/links");
-    request.addQueryParam("limit", "1");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve a Default Link Whitelabel
-
-**This endpoint allows you to retrieve the default link whitelabel.**
-
-Default link whitelabel is the actual link whitelabel to be used when sending messages. If there are multiple link whitelabels, the default is determined by the following order:
-<ul>
-  <li>Validated link whitelabels marked as "default"</li>
-  <li>Legacy link whitelabels (migrated from the whitelabel wizard)</li>
-  <li>Default SendGrid link whitelabel (i.e. 100.ct.sendgrid.net)</li>
-</ul>
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### GET /whitelabel/links/default
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/links/default");
-    request.addQueryParam("domain", "test_string");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve Associated Link Whitelabel
-
-**This endpoint allows you to retrieve the associated link whitelabel for a subuser.**
-
-Link whitelables can be associated with subusers from the parent account. This functionality allows
-subusers to send mail using their parent's link whitelabels. To associate a link whitelabel, the parent account
-must first create a whitelabel and validate it. The parent may then associate that whitelabel with a subuser via the API or the Subuser Management page in the user interface.
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### GET /whitelabel/links/subuser
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/links/subuser");
-    request.addQueryParam("username", "test_string");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Disassociate a Link Whitelabel
-
-**This endpoint allows you to disassociate a link whitelabel from a subuser.**
-
-Link whitelables can be associated with subusers from the parent account. This functionality allows
-subusers to send mail using their parent's link whitelabels. To associate a link whitelabel, the parent account
-must first create a whitelabel and validate it. The parent may then associate that whitelabel with a subuser via the API or the Subuser Management page in the user interface.
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### DELETE /whitelabel/links/subuser
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.DELETE);
-    request.setEndpoint("whitelabel/links/subuser");
-    request.addQueryParam("username", "test_string");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Update a Link Whitelabel
-
-**This endpoint allows you to update a specific link whitelabel. You can use this endpoint to change a link whitelabel's default status.**
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### PATCH /whitelabel/links/{id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.PATCH);
-    request.setEndpoint("whitelabel/links/{id}");
-    request.setBody("{\"default\":true}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Retrieve a Link Whitelabel
-
-**This endpoint allows you to retrieve a specific link whitelabel.**
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### GET /whitelabel/links/{id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.GET);
-    request.setEndpoint("whitelabel/links/{id}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Delete a Link Whitelabel
-
-**This endpoint allows you to delete a link whitelabel.**
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### DELETE /whitelabel/links/{id}
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.DELETE);
-    request.setEndpoint("whitelabel/links/{id}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Validate a Link Whitelabel
-
-**This endpoint allows you to validate a link whitelabel.**
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### POST /whitelabel/links/{id}/validate
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/links/{id}/validate");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-## Associate a Link Whitelabel
-
-**This endpoint allows you to associate a link whitelabel with a subuser account.**
-
-Link whitelables can be associated with subusers from the parent account. This functionality allows
-subusers to send mail using their parent's link whitelabels. To associate a link whitelabel, the parent account
-must first create a whitelabel and validate it. The parent may then associate that whitelabel with a subuser via the API or the Subuser Management page in the user interface.
-
-Email link whitelabels allow all of the click-tracked links you send in your emails to include the URL of your domain instead of sendgrid.net.
-
-For more information, please see our [User Guide](https://sendgrid.com/docs/API_Reference/Web_API_v3/Whitelabel/links.html).
-
-### POST /whitelabel/links/{link_id}/subuser
-
-
-```java
-  try {
-    SendGrid sg = new SendGrid(System.getenv("SENDGRID_API_KEY"));
-    Request request = new Request();
-    request.setMethod(Method.POST);
-    request.setEndpoint("whitelabel/links/{link_id}/subuser");
-    request.setBody("{\"username\":\"jane@example.com\"}");
-    Response response = sg.api(request);
-    System.out.println(response.getStatusCode());
-    System.out.println(response.getBody());
-    System.out.println(response.getHeaders());
-  } catch (IOException ex) {
-    throw ex;
-  }
-  ```
-

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -4,7 +4,7 @@ This documentation provides examples for specific use cases. Please [open an iss
 
 * [Transactional Templates](#transactional-templates)
 * [Legacy Templates](#legacy-templates)
-* [How to Setup a Domain Whitelabel](#domain-whitelabel)
+* [How to Setup a Domain Authentication](#domain-authentication)
 * [How to View Email Statistics](#email-stats)
 
 <a name="transactional-templates"></a>
@@ -217,12 +217,12 @@ public class Example {
 }
 ```
 
-<a name="domain-whitelabel"></a>
-# How to Setup a Domain Whitelabel
+<a name="domain-authentication"></a>
+# How to Setup a Domain Authentication
 
-You can find documentation for how to setup a domain whitelabel via the UI [here](https://sendgrid.com/docs/Classroom/Basics/Whitelabel/setup_domain_whitelabel.html) and via API [here](https://github.com/sendgrid/sendgrid-java/blob/master/USAGE.md#whitelabel).
+You can find documentation for how to setup a domain authentication via the UI [here](https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/) and via API [here](https://github.com/sendgrid/sendgrid-nodejs/blob/master/packages/client/USAGE.md#sender-authentication).
 
-Find more information about all of SendGrid's whitelabeling related documentation [here](https://sendgrid.com/docs/Classroom/Basics/Whitelabel/index.html).
+Find more information about all of SendGrid's authentication related documentation [here](https://sendgrid.com/docs/ui/account-and-settings/).
 
 <a name="email-stats"></a>
 # How to View Email Statistics

--- a/examples/senderauthentication/domains.java
+++ b/examples/senderauthentication/domains.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 //////////////////////////////////////////////////////////////////
-// Create a domain whitelabel.
+// Create a domain authorization.
 // POST /whitelabel/domains
 
 
@@ -31,7 +31,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// List all domain whitelabels.
+// List all domain authorization.
 // GET /whitelabel/domains
 
 
@@ -58,7 +58,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Get the default domain whitelabel.
+// Get the default domain authorization.
 // GET /whitelabel/domains/default
 
 
@@ -80,7 +80,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// List the domain whitelabel associated with the given user.
+// List the domain authorization associated with the given user.
 // GET /whitelabel/domains/subuser
 
 
@@ -102,7 +102,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Disassociate a domain whitelabel from a given user.
+// Disassociate a domain authorization from a given user.
 // DELETE /whitelabel/domains/subuser
 
 
@@ -124,7 +124,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Update a domain whitelabel.
+// Update a domain authorization.
 // PATCH /whitelabel/domains/{domain_id}
 
 
@@ -147,7 +147,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve a domain whitelabel.
+// Retrieve a domain authorization.
 // GET /whitelabel/domains/{domain_id}
 
 
@@ -169,7 +169,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Delete a domain whitelabel.
+// Delete a domain authorization.
 // DELETE /whitelabel/domains/{domain_id}
 
 
@@ -191,7 +191,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Associate a domain whitelabel with a given user.
+// Associate a domain authorization with a given user.
 // POST /whitelabel/domains/{domain_id}/subuser
 
 
@@ -214,7 +214,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Add an IP to a domain whitelabel.
+// Add an IP to a domain authorization.
 // POST /whitelabel/domains/{id}/ips
 
 
@@ -237,7 +237,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Remove an IP from a domain whitelabel.
+// Remove an IP from a domain authorization.
 // DELETE /whitelabel/domains/{id}/ips/{ip}
 
 
@@ -259,7 +259,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Validate a domain whitelabel.
+// Validate a domain authorization.
 // POST /whitelabel/domains/{id}/validate
 
 

--- a/examples/senderauthentication/ips.java
+++ b/examples/senderauthentication/ips.java
@@ -18,7 +18,7 @@ public class CommonExample {
 }
 
 //////////////////////////////////////////////////////////////////
-// Create an IP whitelabel
+// Create a reverse DNS record
 // POST /whitelabel/ips
 
 
@@ -40,7 +40,7 @@ public class Example extends CommonExample {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve all IP whitelabels
+// Retrieve all reverse DNS records
 // GET /whitelabel/ips
 
 
@@ -64,7 +64,7 @@ public class Example extends CommonExample {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve an IP whitelabel
+// Retrieve a reverse DNS record
 // GET /whitelabel/ips/{id}
 
 
@@ -85,7 +85,7 @@ public class Example extends CommonExample {
 }
 
 //////////////////////////////////////////////////////////////////
-// Delete an IP whitelabel
+// Delete a reverse DNS record
 // DELETE /whitelabel/ips/{id}
 
 
@@ -106,7 +106,7 @@ public class Example extends CommonExample {
 }
 
 //////////////////////////////////////////////////////////////////
-// Validate an IP whitelabel
+// Validate a reverse DNS record
 // POST /whitelabel/ips/{id}/validate
 
 

--- a/examples/senderauthentication/links.java
+++ b/examples/senderauthentication/links.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 //////////////////////////////////////////////////////////////////
-// Create a Link Whitelabel
+// Create a Branded Link
 // POST /whitelabel/links
 
 
@@ -33,7 +33,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve all link whitelabels
+// Retrieve all link Branding
 // GET /whitelabel/links
 
 
@@ -56,7 +56,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve a Default Link Whitelabel
+// Retrieve a Default Link Branding
 // GET /whitelabel/links/default
 
 
@@ -79,7 +79,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve Associated Link Whitelabel
+// Retrieve Associated Link Branding
 // GET /whitelabel/links/subuser
 
 
@@ -102,7 +102,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Disassociate a Link Whitelabel
+// Disassociate a Link Branding
 // DELETE /whitelabel/links/subuser
 
 
@@ -125,7 +125,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Update a Link Whitelabel
+// Update a Link Branding
 // PATCH /whitelabel/links/{id}
 
 
@@ -148,7 +148,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Retrieve a Link Whitelabel
+// Retrieve a Link Branding
 // GET /whitelabel/links/{id}
 
 
@@ -170,7 +170,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Delete a Link Whitelabel
+// Delete a Link Branding
 // DELETE /whitelabel/links/{id}
 
 
@@ -192,7 +192,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Validate a Link Whitelabel
+// Validate a Link Branding
 // POST /whitelabel/links/{id}/validate
 
 
@@ -214,7 +214,7 @@ public class Example {
 }
 
 //////////////////////////////////////////////////////////////////
-// Associate a Link Whitelabel
+// Associate a Link Branding
 // POST /whitelabel/links/{link_id}/subuser
 
 


### PR DESCRIPTION
# Fixes #543

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
Per the SendGrid Docs [here](https://github.com/sendgrid/docs/blob/develop/content/docs/glossary/whitelabel.md) as well as an upcoming addition to the Docs in a PR I have submitted [here](https://github.com/sendgrid/docs/pull/4182#discussion_r224903380), the term "Whitelabel" is no longer being used in SendGrid documentation and has been "deprecated" ([see here](https://github.com/sendgrid/docs/pull/4182#discussion_r224903380)), even though the API still references it. 

This PR alters the references to whitelabeling and replaces them with the following:
Whitelabel = Sender Authentication
Domain Whitelabel = Domain Authentication
IP Whitelabel = Reverse DNS
Link Whitelabel = Link branding
