### PR TITLE
Update Jackson dependencies to the latest version

### DIFF
--- a/bin/com/sendgrid/helpers/README.md
+++ b/bin/com/sendgrid/helpers/README.md
@@ -10,7 +10,7 @@ Run the [example](https://github.com/sendgrid/sendgrid-java/tree/master/examples
 
 ```bash
 cd examples/mail
-javac -classpath ../../build/libs/sendgrid-4.2.1-jar.jar:. Example.java && java -classpath ../examples/jackson-core-2.9.5.jar:../../build/libs/sendgrid-4.1.0-jar.jar:. Example
+javac -classpath ../../build/libs/sendgrid-4.2.1-jar.jar:. Example.java && java -classpath ../examples/jackson-core-2.9.9.jar:../../build/libs/sendgrid-4.1.0-jar.jar:. Example
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,9 @@ buildscript {
 
 dependencies {
   compile 'com.sendgrid:java-http-client:4.1.0'
-  compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'
-  compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.5'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
+  compile 'com.fasterxml.jackson.core:jackson-core:2.9.9'
+  compile 'com.fasterxml.jackson.core:jackson-annotations:2.9.9'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
   testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         </license>
     </licenses>
     <properties>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
     </properties>
     <scm>
         <url>https://github.com/sendgrid/sendgrid-java</url>

--- a/src/main/java/com/sendgrid/helpers/README.md
+++ b/src/main/java/com/sendgrid/helpers/README.md
@@ -10,7 +10,7 @@ Run the [example](https://github.com/sendgrid/sendgrid-java/tree/master/examples
 
 ```bash
 cd examples/mail
-javac -classpath ../../build/libs/sendgrid-4.2.1-jar.jar:. Example.java && java -classpath ../examples/jackson-core-2.9.5.jar:../../build/libs/sendgrid-4.1.0-jar.jar:. Example
+javac -classpath ../../build/libs/sendgrid-4.2.1-jar.jar:. Example.java && java -classpath ../examples/jackson-core-2.9.9.jar:../../build/libs/sendgrid-4.1.0-jar.jar:. Example
 ```
 
 ## Usage


### PR DESCRIPTION
Greetings,

The Jackson dependencies used by this project are version `2.9.5`, which are prone to multiple CVE-registered vulnerabilities (https://www.cvedetails.com/vulnerability-list/vendor_id-15866/Fasterxml.html).

Upgrading to `2.9.9` should solve those issues, although I'm afraid I'm in no position to ascertain that.