### PR TITLE
fix: don't use dependency version ranges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
     <dependency>
       <groupId>com.sendgrid</groupId>
       <artifactId>java-http-client</artifactId>
-      <version>[4.2,5.0)</version>
+      <version>4.3.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -300,7 +300,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.1.0</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Fixes https://github.com/sendgrid/sendgrid-java/issues/634

Using a version range like this results in maven attempting to get SNAPSHOT information for the dependency since it's possible a SNAPSHOT release would match the version range. It's not a big deal, but there are better approaches. The idea was we want to pick up the latest 4.X version of java-http-client, but even a version range does not guarantee this. It only guarantees that a 4.X version will be used (not necessarily the latest release). What we really want is the latest non-snapshot, minor version release for all dependencies, not just java-http-client. Also note that Maven version ranges perform basic string comparison so even it they were capable of getting the latest release for a dependency, it might not actually be the latest release if proper semver is used.