### PR TITLE
docs: add multi-recipient examples

### DIFF
--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -3,6 +3,8 @@ This documentation provides examples for specific use cases. Please [open an iss
 # Use Cases
 
 * [Send Mail Examples](examples/helpers/mail/Example.java)
+  * [Send a Single Email to Multiple Recipients](examples/helpers/mail/SingleEmailMultipleRecipients.java)
+  * [Send Multiple Emails to Multiple Recipients](examples/helpers/mail/MultipleEmailsMultipleRecipients.java)
 * [Transactional Templates](#transactional-templates)
 * [Legacy Templates](#legacy-templates)
 * [How to Setup a Domain Authentication](#domain-authentication)

--- a/examples/helpers/mail/MultipleEmailsMultipleRecipients.java
+++ b/examples/helpers/mail/MultipleEmailsMultipleRecipients.java
@@ -16,13 +16,18 @@ public class MultipleEmailsMultipleRecipients {
 
     mail.setFrom(new Email("test@example.com", "Example User"));
     mail.setSubject("Sending with Twilio SendGrid is Fun");
+    mail.setTemplateId("d-12345678901234567890123456789012");
 
     final Personalization personalization1 = new Personalization();
     personalization1.addTo(new Email("test1@example.com", "Example User1"));
+    personalization1.addDynamicTemplateData("name", "Example User1");
+    personalization1.addDynamicTemplateData("city", "Denver");
     mail.addPersonalization(personalization1);
 
     final Personalization personalization2 = new Personalization();
     personalization2.addTo(new Email("test2@example.com", "Example User2"));
+    personalization2.addDynamicTemplateData("name", "Example User2");
+    personalization2.addDynamicTemplateData("city", "San Francisco");
     mail.addPersonalization(personalization2);
 
     mail.addContent(new Content("text/plain", "and easy to do anywhere, even with Java"));

--- a/examples/helpers/mail/MultipleEmailsMultipleRecipients.java
+++ b/examples/helpers/mail/MultipleEmailsMultipleRecipients.java
@@ -16,6 +16,9 @@ public class MultipleEmailsMultipleRecipients {
 
     mail.setFrom(new Email("test@example.com", "Example User"));
     mail.setSubject("Sending with Twilio SendGrid is Fun");
+
+    // Details on how to send an email with dynamic transactional templates:
+    // https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/
     mail.setTemplateId("d-12345678901234567890123456789012");
 
     final Personalization personalization1 = new Personalization();

--- a/examples/helpers/mail/MultipleEmailsMultipleRecipients.java
+++ b/examples/helpers/mail/MultipleEmailsMultipleRecipients.java
@@ -1,0 +1,46 @@
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import com.sendgrid.helpers.mail.objects.Personalization;
+
+import java.io.IOException;
+
+public class MultipleEmailsMultipleRecipients {
+
+  public static void main(String[] args) throws IOException {
+    final Mail mail = new Mail();
+
+    mail.setFrom(new Email("test@example.com", "Example User"));
+    mail.setSubject("Sending with Twilio SendGrid is Fun");
+
+    final Personalization personalization1 = new Personalization();
+    personalization1.addTo(new Email("test1@example.com", "Example User1"));
+    mail.addPersonalization(personalization1);
+
+    final Personalization personalization2 = new Personalization();
+    personalization2.addTo(new Email("test2@example.com", "Example User2"));
+    mail.addPersonalization(personalization2);
+
+    mail.addContent(new Content("text/plain", "and easy to do anywhere, even with Java"));
+    mail.addContent(new Content("text/html", "<strong>and easy to do anywhere, even with Java</strong>"));
+
+    send(mail);
+  }
+
+  private static void send(final Mail mail) throws IOException {
+    final SendGrid client = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    final Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("mail/send");
+    request.setBody(mail.build());
+
+    final Response response = client.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  }
+}

--- a/examples/helpers/mail/SingleEmailMultipleRecipients.java
+++ b/examples/helpers/mail/SingleEmailMultipleRecipients.java
@@ -1,0 +1,44 @@
+import com.sendgrid.Method;
+import com.sendgrid.Request;
+import com.sendgrid.Response;
+import com.sendgrid.SendGrid;
+import com.sendgrid.helpers.mail.Mail;
+import com.sendgrid.helpers.mail.objects.Content;
+import com.sendgrid.helpers.mail.objects.Email;
+import com.sendgrid.helpers.mail.objects.Personalization;
+
+import java.io.IOException;
+
+public class SingleEmailMultipleRecipients {
+
+  public static void main(String[] args) throws IOException {
+    final Mail mail = new Mail();
+
+    mail.setFrom(new Email("test@example.com", "Example User"));
+    mail.setSubject("Sending with Twilio SendGrid is Fun");
+
+    final Personalization personalization = new Personalization();
+    personalization.addTo(new Email("test1@example.com", "Example User1"));
+    personalization.addTo(new Email("test2@example.com", "Example User2"));
+    personalization.addTo(new Email("test3@example.com", "Example User3"));
+    mail.addPersonalization(personalization);
+
+    mail.addContent(new Content("text/plain", "and easy to do anywhere, even with Java"));
+    mail.addContent(new Content("text/html", "<strong>and easy to do anywhere, even with Java</strong>"));
+
+    send(mail);
+  }
+
+  private static void send(final Mail mail) throws IOException {
+    final SendGrid client = new SendGrid(System.getenv("SENDGRID_API_KEY"));
+    final Request request = new Request();
+    request.setMethod(Method.POST);
+    request.setEndpoint("mail/send");
+    request.setBody(mail.build());
+
+    final Response response = client.api(request);
+    System.out.println(response.getStatusCode());
+    System.out.println(response.getBody());
+    System.out.println(response.getHeaders());
+  }
+}


### PR DESCRIPTION
We have similar examples in other languages and they provide a clear distinction between the two use cases.

Fixes #629 