### PR TITLE
fix: Replace `bcprov-jdk15to18` with `bcprov-jdk15on`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.4</version>
             <configuration>
               <relocations>
                 <relocation>
@@ -233,7 +233,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.4</version>
         <configuration>
           <relocations>
             <relocation>
@@ -305,7 +305,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15to18</artifactId>
+      <artifactId>bcprov-jdk15on</artifactId>
       <version>1.66</version>
     </dependency>
   </dependencies>


### PR DESCRIPTION
By upgrading the `maven-shade-plugin` the `bcprov-jdk15on` artifact (which contains JDK 9+ classes) can also be used when building the project using JDK 8. This change reverts d9f4413707c38cd7c702d04574b207da56343002.

Resolves #636.

- [x] I acknowledge that all my contributions will be made under the project's license.