### PR TITLE
fix: Utilize headers set on the Request object

### DIFF
--- a/src/main/java/com/sendgrid/BaseInterface.java
+++ b/src/main/java/com/sendgrid/BaseInterface.java
@@ -268,15 +268,9 @@ public abstract class BaseInterface implements SendGridAPI {
     req.setEndpoint("/" + version + "/" + request.getEndpoint());
     req.setBody(request.getBody());
 
-    for (final Map.Entry<String, String> header : this.requestHeaders.entrySet()) {
-      req.addHeader(header.getKey(), header.getValue());
-    }
-
+    req.getHeaders().putAll(this.requestHeaders);
     req.getHeaders().putAll(request.getHeaders());
-
-    for (final Map.Entry<String, String> queryParam : request.getQueryParams().entrySet()) {
-      req.addQueryParam(queryParam.getKey(), queryParam.getValue());
-    }
+    req.getQueryParams().putAll(request.getQueryParams());
 
     return makeCall(req);
   }

--- a/src/main/java/com/sendgrid/BaseInterface.java
+++ b/src/main/java/com/sendgrid/BaseInterface.java
@@ -272,6 +272,8 @@ public abstract class BaseInterface implements SendGridAPI {
       req.addHeader(header.getKey(), header.getValue());
     }
 
+    req.getHeaders().putAll(request.getHeaders());
+
     for (final Map.Entry<String, String> queryParam : request.getQueryParams().entrySet()) {
       req.addQueryParam(queryParam.getKey(), queryParam.getValue());
     }

--- a/src/test/java/com/sendgrid/SendGridTest.java
+++ b/src/test/java/com/sendgrid/SendGridTest.java
@@ -3190,4 +3190,56 @@ public class SendGridTest {
     sg.removeImpersonateSubuser();
     Assert.assertEquals(sg.getImpersonateSubuser(), null);
    }
+
+  @Test
+  public void test_sendgrid_object_headers_are_used_in_request() throws IOException {
+    Client client = mock(Client.class);
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY, client);
+    sg.addRequestHeader("set-on-sendgrid", "123");
+
+    Request request = new Request();
+
+    sg.api(request);
+    verify(client).api(argThat((Request req) -> req.getHeaders().containsKey("set-on-sendgrid")));
+  }
+
+  @Test
+  public void test_request_headers_are_used_in_request() throws IOException {
+    Client client = mock(Client.class);
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY, client);
+
+    Request request = new Request();
+    request.addHeader("set-on-request", "456");
+
+    sg.api(request);
+    verify(client).api(argThat((Request req) -> req.getHeaders().containsKey("set-on-request")));
+  }
+
+
+  @Test
+  public void test_sendgrid_object_and_request_headers_are_both_used_in_request() throws IOException {
+    Client client = mock(Client.class);
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY, client);
+    sg.addRequestHeader("set-on-sendgrid", "123");
+
+    Request request = new Request();
+    request.addHeader("set-on-request", "456");
+
+    sg.api(request);
+    verify(client).api(argThat((Request req) ->
+            req.getHeaders().containsKey("set-on-sendgrid") && req.getHeaders().containsKey("set-on-request")));
+  }
+
+  @Test
+  public void test_request_headers_override_sendgrid_object_headers() throws IOException {
+    Client client = mock(Client.class);
+    SendGrid sg = new SendGrid(SENDGRID_API_KEY, client);
+    sg.addRequestHeader("set-on-both", "123");
+
+    Request request = new Request();
+    request.addHeader("set-on-both", "456");
+
+    sg.api(request);
+    verify(client).api(argThat((Request req) -> req.getHeaders().get("set-on-both").equals("456")));
+  }
 }


### PR DESCRIPTION
Fixes #214 

This PR makes it so `headers` set on a `Request` object are utilized in final request sent to the SendGrid API. Currently, only the header values set on the `SendGrid` object itself are utilized.

I also swapped the `for each` out for `putAll` - certainly not married to that change if it is unwarranted. 