### PR TITLE
fix: override default gh token

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Add & Commit
         if: matrix.java == '11'
         uses: EndBug/add-and-commit@v8.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.SG_JAVA_GITHUB_TOKEN }}
         with:
           add: 'pom.xml'
           default_author: 'github_actions'

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
     <dependency>
       <groupId>com.sendgrid</groupId>
       <artifactId>java-http-client</artifactId>
-      <version>4.3.9</version>
+      <version>4.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Tested on [this run](https://github.com/sendgrid/sendgrid-java/runs/5697879895?check_suite_focus=true)