### PR TITLE
chore: security upgrade jackson-databind from 2.13.0 to 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </license>
   </licenses>
   <properties>
-    <jackson.version>2.13.0</jackson.version>
+    <jackson.version>2.13.2</jackson.version>
   </properties>
   <scm>
     <url>https://github.com/sendgrid/sendgrid-java</url>


### PR DESCRIPTION
# Changes included in this PR
- Changes to the following files to upgrade the vulnerable dependencies to a fixed version:
pom.xml

# ref
> jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.

https://nvd.nist.gov/vuln/detail/CVE-2020-36518