### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -3,8 +3,14 @@ on:
   pull_request_target:
     types: [ opened, edited, synchronize, reopened ]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
+    permissions:
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     name: Validate title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -78,6 +78,8 @@ jobs:
           DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
 
   notify-on-failure:
+    permissions:
+      contents: none
     name: Slack notify on failure
     if: failure() && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag')
     needs: [ test, deploy ]

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -36,6 +36,8 @@ jobs:
           message: 'chore: update sendgrid-java dependencies'
 
   notify-on-failure:
+    permissions:
+      contents: none
     name: Slack notify on failure
     if: failure()
     needs: [ update-dependencies-and-test ]


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
