### PR TITLE
chore: bump jackson-databind from 2.13.3 to 2.13.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     </license>
   </licenses>
   <properties>
-    <jackson.version>2.13.4</jackson.version>
-    <jackson.databind.version>2.13.4.2</jackson.databind.version>
+    <jackson.version>2.16.1</jackson.version>
+<!--     <jackson.databind.version>2.13.4.2</jackson.databind.version> -->
   </properties>
   <scm>
     <url>https://github.com/sendgrid/sendgrid-java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,8 @@
     </license>
   </licenses>
   <properties>
-    <jackson.version>2.13.3</jackson.version>
+    <jackson.version>2.13.4</jackson.version>
+    <jackson.databind.version>2.13.4.2</jackson.databind.version>
   </properties>
   <scm>
     <url>https://github.com/sendgrid/sendgrid-java</url>
@@ -277,7 +278,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson.databind.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,7 @@
     </license>
   </licenses>
   <properties>
-    <jackson.version>2.16.1</jackson.version>
-<!--     <jackson.databind.version>2.13.4.2</jackson.databind.version> -->
+    <jackson.version>2.14.0</jackson.version>
   </properties>
   <scm>
     <url>https://github.com/sendgrid/sendgrid-java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.databind.version}</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
# Fixes #

Updates jackson-related libraries to 2.13.4 or 2.13.4.2 (latest version for 2.13). This mitigates [CVE-2022-42003](https://www.cve.org/CVERecord?id=CVE-2022-42003) and [CVE-2022-42002](https://www.cve.org/CVERecord?id=CVE-2022-42004).