### PR TITLE
chore: updates bouncy castle to 1.75 (latest 1.7x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,8 +293,8 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.75</version>
     </dependency>
   </dependencies>
   <reporting>


### PR DESCRIPTION
This mitigates CVE-2023-33201.

ref. https://github.com/bcgit/bc-java/wiki/CVE-2023-33201
